### PR TITLE
Referenced a deadline that has already passed.

### DIFF
--- a/Sections/US-States/README.md
+++ b/Sections/US-States/README.md
@@ -1,5 +1,4 @@
 <h1>IAB Privacy&rsquo;s Multi-State Privacy Technical Specifications</h1>
-<p><strong><em>The section specifications included in this directory are in public comment until October 27, 2022. Comments may be submitted to </em></strong><a href="mailto:support@iabtechlab.com" target="_blank" rel="noopener"><strong><em>support@iabtechlab.com</em></strong></a><strong><em>.&nbsp;</em></strong></p>
 <p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform" target="_blank" rel="noopener">GPP</a> defines a way for local standards to &ldquo;plug-in&rdquo; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20specification" target="_blank" rel="noopener">GPP client side API </a>. The IAB Privacy&rsquo;s Multi-State Privacy technical specifications were developed by the IAB Tech Lab&rsquo;s Global Privacy Working Group with the IAB&rsquo;s Legal Affairs Council providing the policy requirements.&nbsp;</p>
 <h2>Relevant Specification Documents</h2>
 <ul>


### PR DESCRIPTION
We should either update the date in the document with an extended deadline, update the paragraph with when the standard was passed, or just remove it. I just removed it in this pull request. Of course, feel free to reject and go with one of the other choices.