### PR TITLE
Correct stub sample code for __gpp

### DIFF
--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -924,7 +924,7 @@ window.__gpp_stub = function ()
  //queue all other commands
  else
  {
-  __cmp.queue.push([].slice.apply(b));
+  __gpp.queue.push([].slice.apply(b));
  }
 };
 window.__gpp_msghandler = function (event)


### PR DESCRIPTION
It previouly called `__cmp` which I believe will error out (no `queue` on undefined)