### PR TITLE
Update to example stub code to support passing command return values to iframes

### DIFF
--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -965,7 +965,7 @@ window.__gpp_msghandler = function (event)
  if (typeof (json) === 'object' && json !== null && '__gppCall' in json)
  {
   var i = json.__gppCall;
-  window.__gpp(i.command, function (retValue, success)
+  var retValue = window.__gpp(i.command, function (retValue, success)
 {
 var returnMsg = {
  '__gppReturn': {
@@ -976,6 +976,14 @@ var returnMsg = {
 };
 event.source.postMessage(msgIsString ? JSON.stringify(returnMsg) : returnMsg, '*');
 },'parameter' in i? i.parameter: null, 'version' in i ? i.version : 1);
+  var returnMsg = {
+   '__gppReturn'  : {
+    'returnValue': retValue,
+    'success'    : true,
+    'callId'     : i.callId
+   }
+  };
+  event.source.postMessage(msgIsString ? JSON.stringify(returnMsg) : JSON.parse(JSON.stringify(returnMsg)), '*');
  }
 };
 if (!('__gpp' in window) || (typeof (window.__gpp) !== 'function'))

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -856,7 +856,7 @@ window.__gpp_addFrame = function (n)
   }
   else
   {
-   window.setTimeout(window.__gppaddFrame, 10, n);
+   window.setTimeout(window.__gpp_addFrame, 10, n);
   }
  }
 };
@@ -978,7 +978,7 @@ event.source.postMessage(msgIsString ? JSON.stringify(returnMsg) : returnMsg, '*
 },'parameter' in i? i.parameter: null, 'version' in i ? i.version : 1);
  }
 };
-if (!('__gpp' in window) || (typeof (window.__gpp) !== 'function')
+if (!('__gpp' in window) || (typeof (window.__gpp) !== 'function'))
 {
  window.__gpp = window.__gpp_stub;
  window.addEventListener('message', window.__gpp_msghandler, false);


### PR DESCRIPTION
This is related to [Issue 46](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/issues/46)

Currently, the example code assumes that all commands support and only respond via callback functions.  This is not the case as all commands directly return values and most do not support callbacks.  

This change in this PR is a proposed solution for exposing the return values from commands to requests originating within iframes.  Also in this change are a couple syntax/typo fixes in the example stub code