### PR TITLE
Update all commands to rely solely on callbacks

### DIFF
--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -168,7 +168,8 @@ cmpId : Number, // IAB assigned CMP ID, may be 0 during stub/loading
 
 sectionList : Array of Number, // may be empty during loading of the CMP
 
-applicableSections: Array of Number, // Section ID considered to be in force for this transaction. In most cases, this field should have a single section ID. In rare occasions where such a single section ID can not be determined, the field may contain up to 2 values. The value can be 0 or a Section ID specified by the Publisher / Advertiser, during stub / load. When no section is applicable, the value will be -1.
+applicableSections: Array of Number, // Section ID considered to be in force for this transaction. In most cases, this field should have a single section ID. In rare occasions where such a single section ID can not be determined, the field may contain up to 2 values. During the transition period which ends on July 1, 2023, the legacy USPrivacy section may be determined as applicable along with another US section. In this case, the field may contain up to 3 values where one of the values is 6, representing the legacy USPrivacy section. The value can be 0 or a Section ID specified by the Publisher / Advertiser, during stub / load. When no section is applicable, the value will be -1.
+
 
 gppString: String // the complete encoded GPP string, may be empty during CMP load
 

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -8,9 +8,14 @@
 	  <td><strong>Version</strong></td>
     <td><strong>Comments</strong></td>
   </tr>
+    <tr>
+      <td>TBD</td>    
+      <td><code>1.1</code></td>
+      <td>Removal of return values in favor of callback functions. Removal of getGPPData command</td>
+    </tr>
   <tr>
-	  <td>TBD</td>    
-<td><code>1.0</code></td>
+	<td>Sept 28, 2022</td>    
+    <td><code>1.0</code></td>
     <td>Published final public version</td>
   </tr>
 </table>
@@ -535,7 +540,7 @@ The key names are a combination of the “IABGPP_” prefix followed by the sect
   </tr>
   <tr>
     <td><code>IABGPP_HDR_Version</code></td>
-    <td>Integer</td>
+    <td>String</td>
     <td>GPP Version</td>
   </tr>
   <tr>
@@ -637,7 +642,7 @@ Below are example key names from existing APIs. For a complete list of key names
     </tr>
   <tr>
 	  <td><code>IABGPP_TCFEU2_CmpVersion</code></td>    
-<td>IAB TECF EU v2 CMP Version</td>
+<td>IAB TCF EU v2 CMP Version</td>
      </tr>
   <tr>
 	  <td><code>IABGPP_TCFEU2_PurposesConsent</code></td>    
@@ -853,7 +858,7 @@ var returnMsg = {
  }
 };
 event.source.postMessage(msgIsString ? JSON.stringify(returnMsg) : returnMsg, '*');
-},'parameter' in i? i.parameter: null, 'version' in i ? i.version : 1);
+},'parameter' in i? i.parameter: null, 'version' in i ? i.version : '1.1');
  }
 };
 if (!('__gpp' in window) || (typeof (window.__gpp) !== 'function'))
@@ -920,7 +925,7 @@ The sent message shall follow the form outlined below. The command, parameter an
   __gppCall: {
     command: "command",
     parameter: “parameter”,
-    version: 1,
+    version: '1.1',
     callId: “randomID”
   }
 }

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -195,7 +195,7 @@ gppString: String // the complete encoded GPP string, may be empty during CMP lo
     <td>cmpStatus</td>
     <td>CMP is finished loading</td>
   </tr>
-  <tr>
+  <tr>  
     <td><code>'error'</code></td>
     <td>cmpStatus</td>
     <td>CMP is in an error state.  A CMP shall not repsond to any other API requests if this cmpStatus is present. A CMP may set this status if, for any reason, it is unable to perform the operation.</td>
@@ -773,11 +773,14 @@ window.__gpp_stub = function ()
  if (cmd === 'ping')
  {
   return {
-  gppVersion      : '1.1', // must be “Version.Subversion”, current: “1.1”
-  cmpStatus       : 'stub', // possible values: stub, loading, loaded, error
-  cmpDisplayStatus: 'hidden', // possible values: hidden, visible, disabled
-  supportedAPIs      : ['tcfeuv2', 'tcfcav2', 'uspv1'], // list of supported APIs
-  cmpId           : 31 // IAB assigned CMP ID, may be 0 during stub/loading
+  gppVersion        : '1.1', // must be “Version.Subversion”, current: “1.1”
+  cmpStatus         : 'stub', // possible values: stub, loading, loaded, error
+  cmpDisplayStatus  : 'hidden', // possible values: hidden, visible, disabled
+  supportedAPIs     : ['tcfeuv2', 'tcfcav2', 'uspv1'], // list of supported APIs
+  cmpId             : 31, // IAB assigned CMP ID, may be 0 during stub/loading
+  sectionList       : [],
+  applicableSections: [-1], //or 0 or ID set by publisher
+  gppString         : ''
   };
  }
  else if (cmd === 'addEventListener')
@@ -795,13 +798,16 @@ window.__gpp_stub = function ()
    eventName : 'listenerRegistered',
    listenerId: lnr, // Registered ID of the listener
    data      : true, // positive signal
-pingData: {
- gppVersion      : '1.1',
- cmpStatus       : 'stub',
- cmpDisplayStatus: 'hidden',
- supportedAPIs   : ['tcfeuv2', 'tcfva', 'usnat'],
- cmpId           : 31
-}
+   pingData: {
+    gppVersion        : '1.1',
+    cmpStatus         : 'stub',
+    cmpDisplayStatus  : 'hidden',
+    supportedAPIs     : ['tcfeuv2', 'tcfva', 'usnat'],
+    cmpId             : 31,
+    sectionList       : [],
+    applicableSections: [-1], //or 0 or ID set by publisher
+    gppString         : ''
+   }
   };
  }
  else if (cmd === 'removeEventListener')
@@ -821,13 +827,16 @@ pingData: {
    eventName : 'listenerRemoved', 
    listenerId: par, // Registered ID of the listener
    data      : success, // status info
-pingData: {
- gppVersion      : '1.1',
- cmpStatus       : 'stub',
- cmpDisplayStatus: 'hidden',
- supportedAPIs   : ['tcfeuv2', 'tcfva', 'usnat'],
- cmpId           : 31
-}
+   pingData: {
+    gppVersion        : '1.1',
+    cmpStatus         : 'stub',
+    cmpDisplayStatus  : 'hidden',
+    supportedAPIs     : ['tcfeuv2', 'tcfva', 'usnat'],
+    cmpId             : 31,
+    sectionList       : [],
+    applicableSections: [-1], //or 0 or ID set by publisher
+    gppString         : ''
+   }
   };
 }
  //these commands must not be queued but may return null while in stub-mode
@@ -924,10 +933,10 @@ The sent message shall follow the form outlined below. The command, parameter an
 ```javascript
 {
   __gppCall: {
-    command: "command",
-    parameter: “parameter”,
+    command: 'command',
+    parameter: 'parameter,
     version: '1.1',
-    callId: “randomID”
+    callId: 'randomID'
   }
 }
 ```

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -116,7 +116,8 @@ All CMPs must support all generic commands. Generic commands are commands that c
 ________
 #### `ping` <a name="ping"></a>
 
-The `ping` command can be used to determine the state of the CMP. 
+The `ping` command can be used to determine the state of the CMP. The callback shall be called with a <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-">PingReturn</a> object as the value of the `data` parameter. A value of `false` will be passed as the argument to the `success` parameter if the CMP fails to process this command.
+
 <table>
   <tr>
     <td><strong>argument</strong></td>
@@ -131,7 +132,7 @@ The `ping` command can be used to determine the state of the CMP.
   <tr>
     <td><code>callback</code></td>
     <td>function</td>
-    <td>function (data: <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-">PingReturn</a>)</td>
+    <td>function (data: <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-">PingReturn</a>, success: boolean)</td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
@@ -323,7 +324,7 @@ A call to the `addEventListener` command must always trigger an immediate call t
 ______
 #### `removeEventListener` <a name="removeeventlistener"></a>
 
-The `removeEventListener` command can be used to remove an existing event listener. The callback shall be called with `false` as the argument for the `success` parameter if the listener could not be removed (e.g. the CMP cannot find a registered listener corresponding to `listenerId`).
+The `removeEventListener` command can be used to remove an existing event listener. The callback shall be called with `false` as the argument for the `data` parameter if the listener could not be removed (e.g. the CMP cannot find a registered listener corresponding to `listenerId`). A value of `false` will be passed as the argument to the `success` parameter if the CMP fails to process this command.
 
 
 <table> 
@@ -340,7 +341,7 @@ The `removeEventListener` command can be used to remove an existing event listen
   <tr>
     <td><code>callback</code></td>
     <td>function</td>
-    <td>function (success: boolean)</td>
+    <td>function (data: boolean, success: boolean)</td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
@@ -361,7 +362,7 @@ __gpp('removeEventListener', myFunction, listenerId);
 __________
 #### `hasSection` <a name="hassection"></a>
 
-The `hasSection` command can be used to detect if the CMP has generated a section of a certain specification. The callback shall be called with `true` as the argument for the `data` parameter if the CMP has generated a section for the requested API prefix string. The `data` parameter may be `null` when the CMP is not yet loaded. The callback shall be called with `false` as the argument for the `success` parameter if the CMP fails to process this command.
+The `hasSection` command can be used to detect if the CMP has generated a section of a certain specification. The callback shall be called with `true` as the argument for the `data` parameter if the CMP has generated a section for the requested API prefix string. The `data` parameter may be `null` when the CMP is not yet loaded. A value of `false` will be passed as the argument to the `success` parameter if the CMP fails to process this command.
 
 
 
@@ -399,7 +400,7 @@ __gpp('hasSection', myFunction, "tcfeuv2");
 ______
 #### `getSection` <a name="getsection"></a>
 
-The `getSection` command can be used to receive the (parsed) object representation of a section of a certain specification. The callback shall be called with the (parsed) object representation as the argument for the `data` parameter. The `data` parameter may be `null` when the CMP is not yet loaded. The callback shall be called with `false` as the argument for the `success` parameter if the CMP fails to process this command. 
+The `getSection` command can be used to receive the (parsed) object representation of a section of a certain specification. The callback shall be called with the (parsed) object representation as the argument for the `data` parameter. The `data` parameter may be `null` when the CMP is not yet loaded. A value of `false` will be passed as the argument to the `success` parameter if the CMP fails to process this command.
 
 
 
@@ -438,7 +439,7 @@ __gpp('getSection', myFunction, "tcfeuv2");
 ______
 #### `getField` <a name="getfield"></a>
 
-The `getField` command can be used to receive a specific field out of a certain section. The callback shall be called with the value of the requested field as the argument for the `data` parameter. The `data` parameter may be `null` when the CMP is not yet loaded. The callback shall be called with `false` as the argument for the `success` parameter if the CMP fails to process this command.
+The `getField` command can be used to receive a specific field out of a certain section. The callback shall be called with the value of the requested field as the argument for the `data` parameter. The `data` parameter may be `null` when the CMP is not yet loaded. A value of `false` will be passed as the argument to the `success` parameter if the CMP fails to process this command.
 
 
 <table>

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -908,7 +908,7 @@ pingData: {
  //queue all other commands
  else
  {
-  __cmp.queue.push([].slice.apply(b));
+  __gpp.queue.push([].slice.apply(b));
  }
 };
 window.__gpp_msghandler = function (event)
@@ -932,7 +932,7 @@ event.source.postMessage(msgIsString ? JSON.stringify(returnMsg) : returnMsg, '*
 },'parameter' in i? i.parameter: null, 'version' in i ? i.version : 1);
  }
 };
-if (!('__gpp' in window) || (typeof (window.__gpp) !== 'function')
+if (!('__gpp' in window) || (typeof (window.__gpp) !== 'function'))
 {
  window.__gpp = window.__gpp_stub;
  window.addEventListener('message', window.__gpp_msghandler, false);

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -155,7 +155,7 @@ This object contains information about the loading status and configuration of t
 ```javascript
 PingReturn = {
 
-gppVersion : String, // must be “Version.Subversion”, current: “1.0”
+gppVersion : String, // must be “Version.Subversion”, current: “1.1”
 
 cmpStatus : String, // possible values: stub, loading, loaded, error
 
@@ -772,7 +772,7 @@ window.__gpp_stub = function ()
  if (cmd === 'ping')
  {
   return {
-  gppVersion      : '1.0', // must be “Version.Subversion”, current: “1.0”
+  gppVersion      : '1.1', // must be “Version.Subversion”, current: “1.1”
   cmpStatus       : 'stub', // possible values: stub, loading, loaded, error
   cmpDisplayStatus: 'hidden', // possible values: hidden, visible, disabled
   supportedAPIs      : ['tcfeuv2', 'tcfcav2', 'uspv1'], // list of supported APIs
@@ -795,7 +795,7 @@ window.__gpp_stub = function ()
    listenerId: lnr, // Registered ID of the listener
    data      : true, // positive signal
 pingData: {
- gppVersion      : '1.0',
+ gppVersion      : '1.1',
  cmpStatus       : 'stub',
  cmpDisplayStatus: 'hidden',
  supportedAPIs   : ['tcfeuv2', 'tcfva', 'usnat'],
@@ -821,7 +821,7 @@ pingData: {
    listenerId: par, // Registered ID of the listener
    data      : success, // status info
 pingData: {
- gppVersion      : '1.0',
+ gppVersion      : '1.1',
  cmpStatus       : 'stub',
  cmpDisplayStatus: 'hidden',
  supportedAPIs   : ['tcfeuv2', 'tcfva', 'usnat'],

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -95,9 +95,8 @@ Every consent manager must provide the following API function:
 Requirements for the interface: 
 - The function <code>__gpp</code> must always be a function and cannot be any other type, even if only temporarily on initialization – the API must be able to handle calls at all times.
 - The command must always be a string.
-- The callback must be either a function or null.
+- The callback must always be a function.
 - Parameter can be of mixed type depending on used command
-- The return value of the function is of mixed type depending on used command
 - If a CMP cannot immediately respond to a query, the CMP must queue all calls to the function and execute them later. The CMP must execute the commands in the same order in which the function was called.
 - A CMP must support all generic commands. All generic commands must always be available when a <code>__gpp</code> function is present on the page. This means that “[stub code](#stubcode)” that supports all generic commands must be in place before/during CMP load.	
 
@@ -124,21 +123,14 @@ The `ping` command can be used to determine the state of the CMP.
   </tr>
   <tr>
     <td><code>callback</code></td>
-    <td>not used</td>
-    <td></td>
+    <td>function</td>
+    <td>function (data: <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-"> PingReturn </a>)</td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
     <td>not used</td>
     <td></td>
-  </tr>
-  <tr>
-    <td><code>return</code></td>
-    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-"> PingReturn object</td>
-    <td></td>
-     </td>
-     </td>
-  </tr>
+  </tr>     
 </table>
 
 
@@ -146,7 +138,9 @@ The `ping` command can be used to determine the state of the CMP.
 *Example:*
 
 ``` javascript
-var PingReturn = __gpp('ping');var PingReturn = __gpp('ping');
+__gpp('ping', pingReturn => {
+  // do something with pingReturn
+});
 ```
 
 #### `PingReturn` <a name="pingreturn"></a>
@@ -234,7 +228,7 @@ The `addEventListener` command can be used to define a callback function (or a p
   <tr>
     <td><code>callback</code></td>
     <td>function</td>
-    <td>function (data: EventListener)</td>
+    <td>function (data: <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#eventlistener-"> EventListener</a>)</td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
@@ -255,11 +249,11 @@ The `addEventListener` command can be used to define a callback function (or a p
 *Example:*
 
 ```javascript
-var EventListenerReturn = __gpp('addEventListener',myFunction);
+__gpp('addEventListener', myFunction);
 ```
 
 
-> **Note:** The `addEventListener` command returns an `EventListener` object immediately. The GPP script will then call the callback function and return a new EventListener object every time the CMP detects a change (see events below). 
+> **Note:** The `addEventListener` command passes an `EventListener` object immediately to the callback function. The GPP script will then call the callback function and return a new EventListener object every time the CMP detects a change (see events below). 
 
 
 #### `EventListener` <a name="eventlistenerobject"></a>
@@ -277,7 +271,7 @@ pingData : object // see PingReturn
 ```
 
 
-A call to the `addEventListener` command must always respond with a return object immediately. When registering new event listeners, the CMP (and stub) must therefore generate new listenerIds for each call to this command.
+A call to the `addEventListener` command must always trigger an immediate call to the callback function. When registering new event listeners, the CMP (and stub) must therefore generate new listenerIds for each call to this command.
 
 
 <table>
@@ -331,7 +325,7 @@ ______
 The `removeEventListener` command can be used to remove an existing event listener.
 
 
-<table>
+<table> 
   <tr>
     <td><strong>argument</strong></td>
     <td><strong>type</strong></td>
@@ -344,20 +338,13 @@ The `removeEventListener` command can be used to remove an existing event listen
   </tr>
   <tr>
     <td><code>callback</code></td>
-    <td>not used</td>
-    <td></td>
+    <td>function</td>
+    <td>function(data: boolean) // True if removed successfully, otherwise false</td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
     <td>number</td>
     <td>ID of the listenerId property that was returned from addEventListener command</td>
-  </tr>
-  <tr>
-    <td><code>return</code></td>
-    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#eventlistener-"> EventListener object</td>
- <td></td>
-     </td>
-     </td>
   </tr>
  </table>
  
@@ -367,7 +354,7 @@ The `removeEventListener` command can be used to remove an existing event listen
 *Example:*
 
 ```javascript
-var EventListenerReturn = __gpp('removeEventListener',null, listenerId);
+__gpp('removeEventListener', myFunction, listenerId);
 ```
 
 __________
@@ -390,20 +377,13 @@ The `hasSection` command can be used to detect if the CMP has generated a sectio
   </tr>
   <tr>
     <td><code>callback</code></td>
-    <td>not used</td>
-    <td></td>
+    <td>function</td>
+    <td>function(data: boolean or null) // True if the specified section is present, otherwise false</td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
     <td>string</td>
     <td>API Prefix string</td>
-  </tr>
-  <tr>
-    <td><code>return</code></td>
-    <td>boolean or null</td>
-    <td>True if the specified section is present, otherwise false</td>
-     </td>
-     </td>
   </tr>
  </table>
  
@@ -414,7 +394,7 @@ Example:
 A client wants to ask the CMP if there is data for IAB TCF v2.0:
 
 ```javascript
-var b = __gpp('hasSection',null, "tcfeuv2");
+__gpp('hasSection', myFunction, "tcfeuv2");
 ```
 
 ______
@@ -437,20 +417,13 @@ The `getSection` command can be used to receive the (parsed) object representati
   </tr>
   <tr>
     <td><code>callback</code></td>
-    <td>not used</td>
-    <td></td>
+    <td>function</td>
+    <td>function(data: object or null) // Section string parsed into an object according to the API specification </td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
     <td>string</td>
     <td>API Prefix string</td>
-  </tr>
-  <tr>
-    <td><code>return</code></td>
-    <td>object or null</td>
-    <td>Section string parsed into an object according to the API specification</td>
-     </td>
-     </td>
   </tr>
  </table>
 
@@ -460,7 +433,7 @@ For example, client can ask the CMP to get the IAB TCF v2.0 TCData:
 
 
 ```javascript
-var s = __gpp('getSection',null, "tcfeuv2");
+__gpp('getSection', myFunction, "tcfeuv2");
 ```
 
 ______
@@ -482,21 +455,15 @@ The `getField` command can be used to receive a specific field out of a certain 
   </tr>
   <tr>
     <td><code>callback</code></td>
-    <td>not used</td>
-    <td></td>
+    <td>function</td>
+    <td>function(data: mixed or null) // Section string parsed into an object according to the API specification</td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
     <td>string</td>
     <td>API Prefix string + "." (dot) + fieldname</td>
   </tr>
-  <tr>
-    <td><code>return</code></td>
-    <td>mixed or null</td>
-    <td>Section string parsed into an object according to the API specification</td>
-     </td>
-     </td>
-  </tr>
+
  </table>
 
 
@@ -504,7 +471,7 @@ The `getField` command can be used to receive a specific field out of a certain 
 For example, a client can ask the CMP to get the last updated field from the IAB TCF v2.0 TCData. 
 
 ```javascript
-var s = __gpp('getField',null, "tcfeuv2.LastUpdated");
+__gpp('getField', myFunction, "tcfeuv2.LastUpdated");
 ```
 
 ______
@@ -526,20 +493,14 @@ The `getGPPData` command can be used in order to receive the current version of 
   </tr>
   <tr>
     <td><code>callback</code></td>
-    <td>not used</td>
-    <td></td>
+    <td>function</td>
+    <td>function(data: <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#gppdata-">GPPData</a> object or null) // Parsed header plus the encoded GPP String with all sections representing the current choices.</td>
+    
   </tr>
   <tr>
     <td><code>parameter</code></td>
     <td>not used</td>
     <td></td>
-  </tr>
-  <tr>
-    <td><code>return</code></td>
-    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#gppdata-">GPPData object or null</td>
-    <td>Parsed header plus the encoded GPP String with all sections representing the current choices.</td>
-     </td>
-     </td>
   </tr>
  </table>
 

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -124,7 +124,7 @@ The `ping` command can be used to determine the state of the CMP.
   <tr>
     <td><code>callback</code></td>
     <td>function</td>
-    <td>function (data: <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-"> PingReturn </a>)</td>
+    <td>function (data: <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-">PingReturn</a>)</td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
@@ -228,19 +228,12 @@ The `addEventListener` command can be used to define a callback function (or a p
   <tr>
     <td><code>callback</code></td>
     <td>function</td>
-    <td>function (data: <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#eventlistener-"> EventListener</a>)</td>
+    <td>function (data: <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#eventlistener-">EventListener</a>, success: boolean)</td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
     <td>not used</td>
     <td></td>
-  </tr>
-  <tr>
-    <td><code>return</code></td>
-    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#eventlistener-"> EventListener object</td>
-    <td></td>
-     </td>
-     </td>
   </tr>
  </table>
  
@@ -339,7 +332,7 @@ The `removeEventListener` command can be used to remove an existing event listen
   <tr>
     <td><code>callback</code></td>
     <td>function</td>
-    <td>function(data: boolean) // True if removed successfully, otherwise false</td>
+    <td>function (success: boolean)</td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
@@ -378,7 +371,7 @@ The `hasSection` command can be used to detect if the CMP has generated a sectio
   <tr>
     <td><code>callback</code></td>
     <td>function</td>
-    <td>function(data: boolean or null) // True if the specified section is present, otherwise false</td>
+    <td>function (data: boolean, success: boolean)</td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
@@ -418,7 +411,7 @@ The `getSection` command can be used to receive the (parsed) object representati
   <tr>
     <td><code>callback</code></td>
     <td>function</td>
-    <td>function(data: object or null) // Section string parsed into an object according to the API specification </td>
+    <td>function (data: object or null, success: boolean)</td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
@@ -456,7 +449,7 @@ The `getField` command can be used to receive a specific field out of a certain 
   <tr>
     <td><code>callback</code></td>
     <td>function</td>
-    <td>function(data: mixed or null) // Section string parsed into an object according to the API specification</td>
+    <td>function (data: mixed or null, success)</td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
@@ -494,7 +487,7 @@ The `getGPPData` command can be used in order to receive the current version of 
   <tr>
     <td><code>callback</code></td>
     <td>function</td>
-    <td>function(data: <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#gppdata-">GPPData</a> object or null) // Parsed header plus the encoded GPP String with all sections representing the current choices.</td>
+    <td>function (data: <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#gppdata-">GPPData</a> or null, success: boolean)</td>
     
   </tr>
   <tr>
@@ -556,7 +549,7 @@ getVendorList
 
 Command:     iabtcfeuv2.getVendorList
 
-Callback:    function(gvl: GlobalVendorList, success: boolean)
+Callback:    function (gvl: GlobalVendorList, success: boolean)
 
 Parameter:   (optional) int or string
 


### PR DESCRIPTION
Resolves issues #23, #51, and #52

Changes in this PR include
* Removed direct return values from all commands
* Added callback support for all commands
* Updated addEventHandler command to return initial EventListener response through callback instead of return value
* Added success parameter to all callbacks
* Fixed 2 typos in the sample stub code
* Removed getGPPData command