### PR TITLE
Updated spec to reflect the changes for GPP API v1.1 and for IAB EU TCF v2.2

### DIFF
--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -345,6 +345,144 @@ A call to the `addEventListener` command must always trigger an immediate call t
   </tr>
 </table>
 
+The “signalStatus” event shall always be the first (if applicable) and last in a chain of events being fired by the CMP. 
+A CMP **must** send all relevant events and it **must** send them in a specific order so that listeners (e.g. vendors) can understand when a task is completed. Whenever the CMP starts to change or is about to change any of the existing sections or is processing user input for an existing GPP string, it **must always** first set "signalStatus" to "not ready" and fire the corresponding event. It can then perform the tasks (e.g. change the sections along with firing the section change events). Only when all tasks are completed, the CMP can set the "signalStatus" to "ready" and fire the corresponding event.
+
+_Event Order Example 1_ 
+The following example illustrates the  events that are fired, and the other order in which they are fired, assuming support for IAB TCF Canada for a new user:
+<div>
+<table>
+<tbody>
+<tr>
+<td><strong>Event Order</strong></td>
+<td><strong>Event Name</strong></td>
+<td><strong>Data</strong></td>
+<td><strong>Description</strong></td>
+</tr>
+<tr>
+<td>1</td>
+<td colspan="3"><em>initial data of PingReturn is {gppVersion:1.1, cmpStatus: loading, cmpDisplayStatus: hidden, signalStatus: not ready, ...}</em></td>
+</tr>
+<tr>
+<td>2</td>
+<td>listenerRegistered</td>
+<td>&nbsp;</td>
+<td>CMP has registered the event listener. Event is immediately fired after registering.</td>
+</tr>
+<tr>
+<td>3</td>
+<td>cmpStatus</td>
+<td>loaded</td>
+<td>CMP is now loaded. Event is fired with name=cmpStatus and data=loaded.</td>
+</tr>
+<tr>
+<td>4</td>
+<td>cmpDisplayStatus</td>
+<td>visible</td>
+<td>CMP now displays the consent layer. Event is fired with name=cmpDisplayStatus and data = visible</td>
+</tr>
+<tr>
+<td>5</td>
+<td colspan="3"><em>User makes their choices and clicks on accept or reject or save</em></td>
+</tr>
+<tr>
+<td>6</td>
+<td>cmpDisplayStatus</td>
+<td>hidden</td>
+<td>CMP closed the consent layer and processes user input. Event is fired with name=cmpDisplayStatus and data=hidden</td>
+</tr>
+<tr>
+<td>7</td>
+<td>sectionChange</td>
+<td>tcfcav1</td>
+<td>CMP changes the section based on user input. Event is fired with name=sectionChange and data=tcfcav1 Note: if multiple sections are present, multiple sectionChange events may occur after another</td>
+</tr>
+<tr>
+<td>8</td>
+<td>signalStatus</td>
+<td>ready</td>
+<td>CMP is done with the processing, vendors can use the data. Event is fired with name=signalStatus and data = ready.</td>
+</tr>
+</tbody>
+</table>
+</div>
+
+_Event Order Example 2_ 
+The following example illustrates the events that are fired, and the order in which they are fired, assuming support for IAB TCF Canada for a returning user with a preexisting choice:
+<div>
+<table>
+<tbody>
+<tr>
+<td><strong>Event Order</strong></td>
+<td><strong>Event Name</strong></td>
+<td><strong>Data</strong></td>
+<td><strong>Description</strong></td>
+</tr>
+<tr>
+<td>1</td>
+<td colspan="3"><em>initial data of PingReturn is {gppVersion:1.1, cmpStatus: loading, cmpDisplayStatus: hidden, signalStatus: not ready, ... }</em></td>
+</tr>
+<tr>
+<td>2</td>
+<td>listenerRegistered</td>
+<td>&nbsp;</td>
+<td>CMP has registered the event listener. Event is immediately fired after registering.</td>
+</tr>
+<tr>
+<td>3</td>
+<td>cmpStatus</td>
+<td>loaded</td>
+<td>CMP is now loaded. Event is fired with name=cmpStatus and data=loaded</td>
+</tr>
+<tr>
+<td>4</td>
+<td>signalStatus</td>
+<td>ready</td>
+<td>CMP is done with the processing (consent information is loaded, no further processing needed, consent layer will not be shown), vendors can use the data. Event is fired with name=signalStatus and data=ready</td>
+</tr>
+<tr>
+<td>5</td>
+<td colspan="3"><em>User clicks on a link or button to resurface the consent layer in order to change their choice</em></td>
+</tr>
+<tr>
+<td>6</td>
+<td>signalStatus</td>
+<td>Not ready</td>
+<td>CMP is expecting changes, vendors should not use the data but wait and pause their processing. Event is fired with name=signalStatus and data=not ready</td>
+</tr>
+<tr>
+<td>7</td>
+<td>cmpDisplayStatus</td>
+<td>visible</td>
+<td>CMP now displays the consent layer. Event is fired with name=cmpDisplayStatus and data=visible</td>
+</tr>
+<tr>
+<td>8</td>
+<td colspan="3"><em>User makes their choices and clicks on accept or reject or save</em></td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+</tr>
+<tr>
+<td>9</td>
+<td>cmpDisplayStatus</td>
+<td>hidden</td>
+<td>CMP closed the consent layer and processes user input. Event is fired with name=cmpDisplayStatus and data=hidden</td>
+</tr>
+<tr>
+<td>10</td>
+<td>sectionChange</td>
+<td>tcfcav1</td>
+<td>CMP changes the section based on user input. Event is fired with name=sectionChange and data=tcfcav1 Note: If multiple sections are present, multiple sectionChange events may occur after another</td>
+</tr>
+<tr>
+<td>11</td>
+<td>signalStatus</td>
+<td>ready</td>
+<td>CMP is done with the processing, vendors can use the data. Event is fired with name=signalStatus and data=ready</td>
+</tr>
+</tbody>
+</table>
+</div>
 ______
 #### `removeEventListener` <a name="removeeventlistener"></a>
 

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -418,7 +418,7 @@ Example:
 A client wants to ask the CMP if there is data for IAB TCF v2:
 
 ```javascript
-__gpp('hasSection', myFunction, "tcfeuv2");
+__gpp('hasSection', myFunction, "tcfcav1");
 ```
 
 ______
@@ -460,7 +460,6 @@ For example, client can ask the CMP to get the IAB TCF CA v1.0 TCData:
 ```javascript
 __gpp('getSection', myFunction, "tcfcav1");
 ```
-A call to ` __gpp('getSection', null, "tcfeuv2");` will return `null`.
 ______
 #### `getField` <a name="getfield"></a>
 
@@ -495,7 +494,7 @@ The `getField` command can be used to receive a specific field out of a certain 
 For example, a client can ask the CMP to get the last updated field from the IAB TCF v2.0 TCData. 
 
 ```javascript
-__gpp('getField', myFunction, "tcfeuv2.LastUpdated");
+__gpp('getField', myFunction, "tcfcav1.LastUpdated");
 ```
 
 ### What are non-generic commands?
@@ -519,7 +518,7 @@ Using the IAB TCF v2.0 as an example, the `getVendorList`command would be define
 ```
 getVendorList
 
-Command:     iabtcfeuv2.getVendorList
+Command:     iabtcfcav1.getVendorList
 
 Callback:    function (gvl: GlobalVendorList, success: boolean)
 
@@ -528,7 +527,7 @@ Parameter:   (optional) int or string
 Calling with this command and a valid vendorListVersion parameter shall return a GlobalVendorList object to the callback function….
 ```
 
-In the example above, a call to` __gpp (‘iabtcfeuv2.getVendorList’,myfunction)` will be treated in the same way as a call to `__tcfapi(‘getVendorList’,2,myfunction)` by the CMP.
+In the example above, a call to` __gpp (‘iabtcfcav1.getVendorList’,myfunction)` will be treated in the same way as a call to `__tcfapi(‘getVendorList’,2,myfunction)` by the CMP.
 
 
 __________
@@ -800,7 +799,7 @@ window.__gpp_stub = function ()
   gppVersion        : '1.1', // must be “Version.Subversion”, current: “1.1”
   cmpStatus         : 'stub', // possible values: stub, loading, loaded, error
   cmpDisplayStatus  : 'hidden', // possible values: hidden, visible, disabled
-  supportedAPIs     : ['tcfeuv2', 'tcfcav2', 'uspv1'], // list of supported APIs
+  supportedAPIs     : ['tcfeuv2', 'tcfcav1', 'uspv1'], // list of supported APIs
   cmpId             : 31, // IAB assigned CMP ID, may be 0 during stub/loading
   sectionList       : [],
   applicableSections: [-1], //or 0 or ID set by publisher
@@ -826,7 +825,7 @@ window.__gpp_stub = function ()
     gppVersion        : '1.1',
     cmpStatus         : 'stub',
     cmpDisplayStatus  : 'hidden',
-    supportedAPIs     : ['tcfeuv2', 'tcfva', 'usnat'],
+    supportedAPIs     : ['tcfeuv2', 'tcfcav1', 'tcfva', 'usnat'],
     cmpId             : 31,
     sectionList       : [],
     applicableSections: [-1], //or 0 or ID set by publisher
@@ -855,7 +854,7 @@ window.__gpp_stub = function ()
     gppVersion        : '1.1',
     cmpStatus         : 'stub',
     cmpDisplayStatus  : 'hidden',
-    supportedAPIs     : ['tcfeuv2', 'tcfva', 'usnat'],
+    supportedAPIs     : ['tcfeuv2', 'tcfeuv1', 'tcfva', 'usnat'],
     cmpId             : 31,
     sectionList       : [],
     applicableSections: [-1], //or 0 or ID set by publisher

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -346,10 +346,12 @@ A call to the `addEventListener` command must always trigger an immediate call t
 </table>
 
 The “signalStatus” event shall always be the first (if applicable) and last in a chain of events being fired by the CMP. 
+
 A CMP **must** send all relevant events and it **must** send them in a specific order so that listeners (e.g. vendors) can understand when a task is completed. Whenever the CMP starts to change or is about to change any of the existing sections or is processing user input for an existing GPP string, it **must always** first set "signalStatus" to "not ready" and fire the corresponding event. It can then perform the tasks (e.g. change the sections along with firing the section change events). Only when all tasks are completed, the CMP can set the "signalStatus" to "ready" and fire the corresponding event.
 
-_Event Order Example 1_ 
-The following example illustrates the  events that are fired, and the other order in which they are fired, assuming support for IAB TCF Canada for a new user:
+_Event Order Example 1:_ 
+
+The following example illustrates the  events that are fired, and the other order in which they are fired, assuming support for IAB TCF Canada for a new user.
 <div>
 <table>
 <tbody>
@@ -407,8 +409,9 @@ The following example illustrates the  events that are fired, and the other orde
 </table>
 </div>
 
-_Event Order Example 2_ 
-The following example illustrates the events that are fired, and the order in which they are fired, assuming support for IAB TCF Canada for a returning user with a preexisting choice:
+_Event Order Example 2:_ 
+
+The following example illustrates the events that are fired, and the order in which they are fired, assuming support for IAB TCF Canada for a returning user with a preexisting choice.
 <div>
 <table>
 <tbody>
@@ -483,7 +486,8 @@ The following example illustrates the events that are fired, and the order in wh
 </tbody>
 </table>
 </div>
-______
+
+___________
 #### `removeEventListener` <a name="removeeventlistener"></a>
 
 The `removeEventListener` command can be used to remove an existing event listener. The callback shall be called with `false` as the argument for the `data` parameter if the listener could not be removed (e.g. the CMP cannot find a registered listener corresponding to `listenerId`). A value of `false` will be passed as the argument to the `success` parameter if the CMP fails to process this command.

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -223,7 +223,7 @@ gppString: String // the complete encoded GPP string, may be empty during CMP lo
   <tr>
     <td><code>Null / not set</code></td>
     <td>cmpDisplayStatus</td>
-    <td>Is NULL when there is no display layer. Vendors should rely solely on signalStatus.</td>
+    <td>Is NULL when there is no display layer. Display layer refers to a modal that the user may interact with to express their choices. When no such modal is present, the value is NULL,  e.g. when there is only a Do Not Sell or Share Personal Data link on the page that when clicked does not launch a modal. In this example, vendors should rely solely on signalStatus and the cmpDisplayStatus will be NULL / not set.</td>
     </tr>
     <tr>
     <td><code>'not ready'</code></td>
@@ -233,7 +233,7 @@ gppString: String // the complete encoded GPP string, may be empty during CMP lo
   <tr>
     <td><code>'ready'</code></td>
     <td>signalStatus</td>
-    <td>The CMP is ready to respond to any calling scripts with the corresponding GPP string and applicable section ids.</td>
+    <td>The CMP is ready to respond to any calling scripts with the corresponding GPP string and applicable section ids. The ‘ready’ status should only be sent when the GPP string contains the section that is currently applicable with the user’s current choices reflected.  E.g. the ‘ready’ status should be signaled when applicableSection == -1 or applicableSection != 1 and the GPP string contains the section corresponding to applicableSection reflecting the user’s current choices.</td>
     </tr>
 </table>
 

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -911,7 +911,7 @@ if(__gpp)
  __gpp('addEventListener', function (evt)
  {
   //callback will receive all events, we only want to react on TCF canada events
-  if(evt.pingData.currentAPI !== 'tcfcav2'){return ;}
+  if(evt.pingData.currentAPI !== 'tcfcav1'){return ;}
 
   //react on changes or when the data is loaded
   if(
@@ -923,18 +923,18 @@ if(__gpp)
       evt.pingData.cmpDisplayStatus !== 'visible'
      )
      // optional additional/instead check:
-     // __gpp('hasSection', null, 'tcfcav2') === true
+     // __gpp('hasSection', null, 'tcfcav1') === true
     )
   {
-   var consentData =__gpp('getSection', null, 'tcfcav2');
+   var consentData =__gpp('getSection', null, 'tcfcav1');
    //will return the parsed IAB TCF Canada TCstring. All info is in there.	
 
    var vendorConsent = consentData.VendorExpressConsent; 
-   // equivalent to: __gpp('getField', null, 'tcfcav2.VendorExpressConsent');
+   // equivalent to: __gpp('getField', null, 'tcfcav1.VendorExpressConsent');
    var vendorImpConsent = consentData.VendorImpliedConsent;
-   // equivalent to: __gpp('getField', null, 'tcfcav2.VendorImpliedConsent');
+   // equivalent to: __gpp('getField', null, 'tcfcav1.VendorImpliedConsent');
    var purposeConsent = consentData.PurposesExpressConsent; 
-   // equivalent to: __gpp('getField', null, 'tcfcav2.PurposesExpressConsent');
+   // equivalent to: __gpp('getField', null, 'tcfcav1.PurposesExpressConsent');
    // ... do something Canadian !
   }
  });

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -415,7 +415,7 @@ The `hasSection` command can be used to detect if the CMP has generated a sectio
  
 Example:
 
-A client wants to ask the CMP if there is data for IAB TCF v2:
+A client wants to ask the CMP if there is data for IAB TCF CA v1.0:
 
 ```javascript
 __gpp('hasSection', myFunction, "tcfcav1");
@@ -424,8 +424,9 @@ __gpp('hasSection', myFunction, "tcfcav1");
 ______
 #### `getSection` <a name="getsection"></a>
 
-The `getSection` command can be used to receive the (parsed) object representation of a section of a certain specification. 
-The callback shall be called with the (parsed) object representation as the argument for the `data` parameter. The `data` parameter may be `null` for sections that don't allow accessing the section data object outside an event handler.  It may also be `null` when the CMP is not yet loaded.
+The `getSection` command can be used to receive the (parsed) representation of a section of a certain specification. The callback shall be called with the (parsed) representation as the argument for the data parameter. The parsed representation of a section is an array of objects, where each object represents one sub-section of this section in the order that is given by the section specification. For example, the data parameter for the TCF Canada will be an array with one or two objects (Core sub-section plus optional publisher purposes sub-section). Each object is composed of the fields defined by the section specification.
+
+The data parameter may be `null` for sections that don't allow accessing the section data object outside an event handler. It may also be `null` when the CMP is not yet loaded.
 
 
 
@@ -443,7 +444,7 @@ The callback shall be called with the (parsed) object representation as the argu
   <tr>
     <td><code>callback</code></td>
     <td>function</td>
-    <td>function (data: object or null, success: boolean)</td>
+    <td>function (data: array of objects or null, success: boolean)</td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
@@ -458,8 +459,32 @@ For example, client can ask the CMP to get the IAB TCF CA v1.0 TCData:
 
 
 ```javascript
-__gpp('getSection', myFunction, "tcfcav1");
+__gpp('getSection', myFunction, "tcfcav1"); 
 ```
+
+Example value of data passed to the callback: 
+```javascript
+[
+ /* Core Sub-section */
+ {
+  Version:1, 
+  Created: Date (Thu Apr 13 2023 18:07:12 GMT+0200),
+  LastUpdated: Date (Thu Apr 13 2023 18:07:12 GMT+0200),
+  CmpId: 31, 
+  CmpVersion: 123,
+  ConsentScreen: 5,
+  ...
+  }, 
+  /* Publisher Purposes Sub-section (optional) */
+ {
+  subsectionType:3, 
+  PubPurposesExpressConsent : [1,2,3,4,5],
+  PubPurposesImpliedConsent  : [6,7,8,9],
+  ...
+  } 
+ ]
+```
+
 ______
 #### `getField` <a name="getfield"></a>
 
@@ -491,7 +516,7 @@ The `getField` command can be used to receive a specific field out of a certain 
 
 
 
-For example, a client can ask the CMP to get the last updated field from the IAB TCF v2.0 TCData. 
+For example, a client can ask the CMP to get the last updated field from the IAB TCF CA v1.0 TCData. 
 
 ```javascript
 __gpp('getField', myFunction, "tcfcav1.LastUpdated");
@@ -513,7 +538,7 @@ Parameter:   data type       or   “not used”
 A description of the command, what it does, what it’s meant for, when to use it and how.
 ```
 
-Using the IAB TCF v2.0 as an example, the `getVendorList`command would be defined as: 
+Using the IAB TCF CA v1.0 as an example, the `getVendorList`command would be defined as: 
 
 ```
 getVendorList

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -164,7 +164,7 @@ cmpDisplayStatus: String, // possible values: hidden, visible, disabled
 
 signalStatus : String, // possible values: not ready, ready
 
-supportedAPIs : Array of string, // list of supported APIs (prefix strings), e.g. used while loading. Example: ["tcfeuv2","uspv1"] 
+supportedAPIs : Array of string, // list of supported APIs (section ids and prefix strings), e.g. used while loading. Example: ["2:tcfeuv2","6:uspv1"] 
 
 cmpId : Number, // IAB assigned CMP ID, may be 0 during stub/loading
 
@@ -967,7 +967,7 @@ window.__gpp_stub = function ()
   gppVersion        : '1.1', // must be “Version.Subversion”, current: “1.1”
   cmpStatus         : 'stub', // possible values: stub, loading, loaded, error
   cmpDisplayStatus  : 'hidden', // possible values: hidden, visible, disabled
-  supportedAPIs     : ['tcfeuv2', 'tcfcav1', 'uspv1'], // list of supported APIs
+  supportedAPIs     : ['2:tcfeuv2', '5:tcfcav1', '6:uspv1'], // list of supported APIs
   cmpId             : 31, // IAB assigned CMP ID, may be 0 during stub/loading
   sectionList       : [],
   applicableSections: [-1], //or 0 or ID set by publisher
@@ -993,7 +993,7 @@ window.__gpp_stub = function ()
     gppVersion        : '1.1',
     cmpStatus         : 'stub',
     cmpDisplayStatus  : 'hidden',
-    supportedAPIs     : ['tcfeuv2', 'tcfcav1', 'usva', 'usnat'],
+    supportedAPIs     : ['2:tcfeuv2', '5:tcfcav1', '9:usva', '7:usnat'],
     cmpId             : 31,
     sectionList       : [],
     applicableSections: [-1], //or 0 or ID set by publisher
@@ -1022,7 +1022,7 @@ window.__gpp_stub = function ()
     gppVersion        : '1.1',
     cmpStatus         : 'stub',
     cmpDisplayStatus  : 'hidden',
-    supportedAPIs     : ['tcfeuv2', 'tcfeuv1', 'tcfva', 'usnat'],
+    supportedAPIs     : ['2:tcfeuv2', '5:tcfcav1', '9:usva', '7:usnat'],
     cmpId             : 31,
     sectionList       : [],
     applicableSections: [-1], //or 0 or ID set by publisher

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -9,7 +9,7 @@
     <td><strong>Comments</strong></td>
   </tr>
     <tr>
-      <td>TBD</td>    
+      <td>June 2023</td>    
       <td><code>1.1</code></td>
       <td>Removal of return values in favor of callback functions. Removal of getGPPData command</td>
     </tr>
@@ -170,10 +170,11 @@ cmpId : Number, // IAB assigned CMP ID, may be 0 during stub/loading
 
 sectionList : Array of Number, // may be empty during loading of the CMP
 
-applicableSections: Array of Number, // Section ID considered to be in force for this transaction. In most cases, this field should have a single section ID. In rare occasions where such a single section ID can not be determined, the field may contain up to 2 values. During the transition period which ends on July 1, 2023, the legacy USPrivacy section may be determined as applicable along with another US section. In this case, the field may contain up to 3 values where one of the values is 6, representing the legacy USPrivacy section. The value can be 0 or a Section ID specified by the Publisher / Advertiser, during stub / load. When no section is applicable, the value will be [-1].
-
+applicableSections: Array of Number, // Section ID considered to be in force for this transaction. In most cases, this field should have a single section ID. In rare occasions where such a single section ID can not be determined, the field may contain up to 2 values. During the transition period which ends on September 30, 2023, the legacy USPrivacy section may be determined as applicable along with another US section. In this case, the field may contain up to 3 values where one of the values is 6, representing the legacy USPrivacy section. The value can be 0 or a Section ID specified by the Publisher / Advertiser, during stub / load. When no section is applicable, the value will be [-1].
 
 gppString: String // the complete encoded GPP string, may be empty during CMP load
+
+parsedSections: Object // The parsedSections property represents an object of all parsed sections of the gppString property that are supported by the API on this page (see supportedAPIs property). The object contains one property for each supported API with the name of the API as the property name and the value as a parsed representation of this section (similar to getSection command). If a section is supported but not represented in the gppString, it is omitted in the parsedSections object.
 
 }
 
@@ -1075,24 +1076,26 @@ The following example demonstrates how a vendor can listen to changes for IAB TC
 ```javascript
 if(__gpp)
 {
- __gpp('addEventListener', function (evt)
+ __gpp('addEventListener', function (evt, success)
  {
   //callback will receive all events, we only want to react on signalStatus ready events
-  if(evt.eventName !== 'signalStatus' || evt.data !== 'ready'){return ;}
+  if(evt.eventName !== 'signalStatus' || evt.data !== 'ready')
+  {return ;}
 
-  //if only the TC String is needed, it can be taken directly from pingData.gppString
+  //if only the GPP String is needed, it can be taken directly from pingData.gppString
   var gppString = evt.pingData.gppString;
 	 
   //get the data from the TCF Canada section
-  __gpp('getSection',function(data, success)){
-  if(data === null){return ;}
-	 
+  //Note: You might also want to check if TCF Canada is in the pingData.applicableSections
+  if ('tcfcav1' in evt.pingData.parsedSections) 
+  { 
+   var data = evt.pingData.parsedSections.tcfcav1;
    var vendorConsent = data[0].VendorExpressConsent; 
    var vendorImpConsent = data[0].VendorImpliedConsent;
    var purposeConsent = data[0].PurposesExpressConsent; 
    // ... do something Canadian !
   }
- }, 'tcfcav1');
+ });
 }
 ```
 

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -411,7 +411,7 @@ The `hasSection` command can be used to detect if the CMP has generated a sectio
 
 Example:
 
-A client wants to ask the CMP if there is data for IAB TCF v2.0:
+A client wants to ask the CMP if there is data for IAB TCF v2:
 
 ```javascript
 var b = __gpp('hasSection',null, "tcfeuv2");
@@ -420,7 +420,8 @@ var b = __gpp('hasSection',null, "tcfeuv2");
 ______
 #### `getSection` <a name="getsection"></a>
 
-The `getSection` command can be used to receive the (parsed) object representation of a section of a certain specification. Please note that the command may return null when the CMP is not yet loaded. 
+The `getSection` command can be used to receive the (parsed) object representation of a section of a certain specification.<br>
+Please note that this command returns `null` for sections that don't allow accessing the section data object outside an event handler. It may also return `null` when the CMP is not yet loaded.
 
 
 
@@ -456,17 +457,18 @@ The `getSection` command can be used to receive the (parsed) object representati
 
 
 
-For example, client can ask the CMP to get the IAB TCF v2.0 TCData: 
+For example, client can ask the CMP to get the IAB TCF CA v1.0 TCData: 
 
 
 ```javascript
-var s = __gpp('getSection',null, "tcfeuv2");
+var s = __gpp('getSection', null, "tcfcav1");
 ```
-
+A call to ` __gpp('getSection', null, "tcfeuv2");` will return `null`.
 ______
 #### `getField` <a name="getfield"></a>
 
-The `getField` command can be used to receive a specific field out of a certain section. Please note that the command may return `null` when the CMP is not yet loaded. 
+The `getField` command can be used to receive a specific field out of a certain section.<br>
+Please note that this command returns `null` for fields in sections that don't allow accessing the section data object outside an event handler. It may also return `null` when the CMP is not yet loaded.
 
 
 <table>
@@ -501,11 +503,12 @@ The `getField` command can be used to receive a specific field out of a certain 
 
 
 
-For example, a client can ask the CMP to get the last updated field from the IAB TCF v2.0 TCData. 
+For example, a client can ask the CMP to get the last updated field from the IAB TCF CA v1.0 TCData.
 
 ```javascript
-var s = __gpp('getField',null, "tcfeuv2.LastUpdated");
+var s = __gpp('getField', null, "tcfcav1.LastUpdated");
 ```
+A call to ` __gpp('getField', null, "tcfeuv2.LastUpdated);` will return `null`.
 
 ______
 #### `getGPPData` <a name="getgppdata"></a>

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -162,6 +162,8 @@ cmpStatus : String, // possible values: stub, loading, loaded, error
 
 cmpDisplayStatus: String, // possible values: hidden, visible, disabled
 
+signalStatus : String, // possible values: not ready, ready
+
 supportedAPIs : Array of string, // list of supported APIs (prefix strings), e.g. used while loading. Example: ["tcfeuv2","uspv1"] 
 
 cmpId : Number, // IAB assigned CMP ID, may be 0 during stub/loading
@@ -218,6 +220,21 @@ gppString: String // the complete encoded GPP string, may be empty during CMP lo
      </td>
      </td>
   </tr>
+  <tr>
+    <td><code>Null / not set</code></td>
+    <td>cmpDisplayStatus</td>
+    <td>Is NULL when there is no display layer. Vendors should rely solely on signalStatus.</td>
+    </tr>
+    <tr>
+    <td><code>'not ready'</code></td>
+    <td>signalStatus</td>
+    <td>The CMP is not ready to respond to any calling scripts with the corresponding GPP string and applicable section ids.</td>
+  </tr>	
+  <tr>
+    <td><code>'ready'</code></td>
+    <td>signalStatus</td>
+    <td>The CMP is ready to respond to any calling scripts with the corresponding GPP string and applicable section ids.</td>
+    </tr>
 </table>
 
 
@@ -301,7 +318,13 @@ A call to the `addEventListener` command must always trigger an immediate call t
   <tr>
     <td><code>cmpDisplayStatus</code></td>
     <td>string</td>
-    <td>Event is called whenever the display status of the CMP changes (e.g. the CMP shows the consent layer). The data property will contain the new display status (e.g. “visible”).</td>
+    <td>Event is called whenever the display status of the CMP changes (e.g. the CMP shows the consent layer). The data property will contain the new display status (e.g. “visible”). Note that this is only applicable when a consent layer is displayed.</td>
+    </tr>
+    <tr>
+    <td><code>signalStatus</code></td>
+    <td>string</td>
+    <td>Event is called whenever the signalStatus changes.
+   </td>
     </tr>
   <tr>
     <td><code>error</code></td>

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -849,7 +849,7 @@ Below are example key names from existing APIs. For a complete list of key names
      </tr>
   <tr>
 	  <td><code>IABGPP_TCFCA1_Version</code></td>    
-<td>IAB TCF CA v2 Version number (see  <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/Canada">IAB TCF CA v1 specification)</td>
+<td>IAB TCF CA v1 Version number (see  <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/Canada">IAB TCF CA v1 specification)</td>
    </tr>
   <tr>
 	  <td><code>IABGPP_TCFCA1_Created</code></td>    
@@ -992,7 +992,7 @@ window.__gpp_stub = function ()
     gppVersion        : '1.1',
     cmpStatus         : 'stub',
     cmpDisplayStatus  : 'hidden',
-    supportedAPIs     : ['tcfeuv2', 'tcfcav1', 'tcfva', 'usnat'],
+    supportedAPIs     : ['tcfeuv2', 'tcfcav1', 'usva', 'usnat'],
     cmpId             : 31,
     sectionList       : [],
     applicableSections: [-1], //or 0 or ID set by publisher

--- a/Sections/Canada/GPPExtension: IAB Canada TCF.md
+++ b/Sections/Canada/GPPExtension: IAB Canada TCF.md
@@ -17,7 +17,7 @@
 </tr>
 <tr>
 <td>Client side API prefix</td>
-<td>tcfca</td>
+<td>tcfcav1</td>
 <td>The IAB TCF Canada is registered with client side API prefix &ldquo;tcfcav1&rdquo; in the GPP Client Side API.</td>
 </tr>
 </tbody>

--- a/Sections/Canada/TCF EU TCF CA Comparison.md
+++ b/Sections/Canada/TCF EU TCF CA Comparison.md
@@ -1946,7 +1946,7 @@ The registration process is described here: [https://iabeurope.eu/tcf](https://i
     *   List of Special Purposes to transparently disclose as their legitimate interest that a user has no right to object.
     *   List of Features they use across Purposes.
     *   List of Special Features they use across Purposes.
-    *   GDPR/privacy policy page URL.
+    *   A list of GDPR/privacy policy page URLs.
     *   HTTP “overflow” options which includes a <code>GET</code> request maximum size in kilobytes to help diagnose problems with TC String passing as well as limit oversized strings.
 
 
@@ -2079,7 +2079,7 @@ Here is an annotated example of the GVL’s JSON format:
 {
   "gvlSpecificationVersion": 2,
   "vendorListVersion": 133, // incremented with each published file change
-  "tcfPolicyVersion": 2, // The TCF MO will increment this value whenever a GVL change (such as adding a new Purpose or Feature or a change in Purpose wording) legally invalidates existing TC Strings and requires CMPs to re-establish transparency and consent from users. TCF Policy changes should be relatively infrequent and only occur when necessary to support changes in global mandate. If the policy version number in the latest GVL is different from the value in your TC String, then you need to re-establish transparency and consent for that user. A version 1 format TC String is considered to have a version value of 1.
+  "tcfPolicyVersion": 1, // The TCF MO will increment this value whenever a GVL change (such as adding a new Purpose or Feature or a change in Purpose wording) legally invalidates existing TC Strings and requires CMPs to re-establish transparency and consent from users. TCF Policy changes should be relatively infrequent and only occur when necessary to support changes in global mandate. If the policy version number in the latest GVL is different from the value in your TC String, then you need to re-establish transparency and consent for that user. A version 1 format TC String is considered to have a version value of 1.
   "lastUpdated": "2018-05-28T00:00:00Z",
   "purposes": {
 
@@ -2209,8 +2209,9 @@ Here is an annotated example of the GVL’s JSON format:
    * empty. List of Special Features the Vendor may utilize when performing
    * some declared Purposes processing.
    *
-   * "policyUrl": url string, REQUIRED URL to the Vendor's privacy policy
-   * document.
+   * "urls": an array of url objects representing language, policy url and
+   * legitimate interest url. At least one entry is REQUIRED. Up to 40 languages
+   * can be specified.
    *
    * "deletedDate": date string ("2019-05-28T00:00:00Z") OPTIONAL, If present,
    * vendor is considered deleted after this date/time and MUST NOT be
@@ -2235,8 +2236,17 @@ Here is an annotated example of the GVL’s JSON format:
     "flexiblePurposes": [1, 2],
     "features": [1, 2],
     "specialFeatures": [1, 2],
-    "policyUrl": "https://vendorname.com/gdpr.html",
-    "deletedDate": "2019-02-28T00:00:00Z",
+    "urls": [
+        {
+          "langId": "en",
+          "privacy": "https://vendorname.com/myPrivacyPolicy.html"
+        },
+        {
+          "langId": "fr",
+          "privacy": "https://vendorname.com/fr/myPrivacyPolicy.html"
+        }
+     ],
+    "deletedDate": "2023-05-28T00:00:00Z",
     "overflow": {
       "httpGetLimit": 32   /* 32 or 128 are supported options */
       }

--- a/Sections/EEA/GPPExtension: IAB Europe TCF.md
+++ b/Sections/EEA/GPPExtension: IAB Europe TCF.md
@@ -248,14 +248,6 @@ The publisher purposes segment is appended to the core segment by using the “.
 
 # Client side API
 
-The client side API does not expose the following custom GPP commands:
-
-## getTCData
-
-This command is deprecated in TCF EU v2.2.
-
-
-
 ## Key Names
 
 In the mobile or CTV context, the key names to be used in GPP are listed below. For complete details on the expected values for each key listed below, see the [IAB TCF EU v2 specification.](https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#what-is-the-cmp-in-app-internal-structure-for-the-defined-api)

--- a/Sections/EEA/GPPExtension: IAB Europe TCF.md
+++ b/Sections/EEA/GPPExtension: IAB Europe TCF.md
@@ -115,7 +115,7 @@ The core segment must always be present. It consists of the following fields:
       <li>1 Consent</li>
       <li>0 Consent</li>
     </ul>
-    The user’s consent value for each Purpose established on the legal basis of consent.<br><br>  <br><br>The Purposes are numerically identified and published in the Global Vendor List. From left to right, Purpose 1 maps to the 0th bit, purpose 24 maps to the bit at index 23. Special Purposes are a different ID space and not included in this field.</td>
+    The user’s consent value for each Purpose established on the legal basis of consent.<br><br>The Purposes are numerically identified and published in the Global Vendor List. From left to right, Purpose 1 maps to the 0th bit, purpose 24 maps to the bit at index 23. Special Purposes are a different ID space and not included in this field.</td>
   </tr>
   <tr>
   <td>PurposesLITransparency</td>
@@ -125,7 +125,8 @@ The core segment must always be present. It consists of the following fields:
       <li>1 legitimate interest estalished</li>
       <li>0 legitimate interest was NOT established or it was established but user exercised their “Right to Object” to the Purpose</li>
     </ul>
-      The Purpose’s transparency requirements are met for each Purpose on the legal basis of legitimate interest and the user has not exercised their “Right to Object” to that Purpose.<br><br>By default or if the user has exercised their “Right to Object” to a Purpose, the corresponding bit for that Purpose is set to 0. From left to right, Purpose 1 maps to the 0th bit, purpose 24 maps to the bit at index 23. Special Purposes are a different ID space and not included in this field.</td>
+      The Purpose’s transparency requirements are met for each Purpose on the legal basis of legitimate interest and the user has not exercised their “Right to Object” to that Purpose.<br><br>By default or if the user has exercised their “Right to Object” to a Purpose, the corresponding bit for that Purpose is set to 0. From left to right, Purpose 1 maps to the 0th bit, purpose 24 maps to the bit at index 23. Special Purposes are a different ID space and not included in this field.<br>
+      Note: With TCF v2.2 support for legitimate interest for purpose 3 to 6 has been deprecated. Bits 2 to 5 are required to be set to <code>0</code>.</td>
     </tr>
     <tr>
   <td>PurposeOneTreatment</td>
@@ -178,7 +179,7 @@ The core segment must always be present. It consists of the following fields:
 
 ## Disclosed Vendors Segment
 
-The disclosed vendors segment is appended to the core segment by using the “.” (dot) delimiter. This is an optional TC String segment. The segment fields are:
+The disclosed vendors segment is appended to the core segment by using the “.” (dot) delimiter. This is an optional TC String segment. It may be used by a CMP while storing TC Strings, but must not be included in the TC String when returned by the CMP API. The segment fields are:
 
 <table>
 <tr>
@@ -251,25 +252,7 @@ The client side API does not expose the following custom GPP commands:
 
 ## getTCData
 
-
-<table>
-<tr>
-<td>Command:</td>
-<td>tcfcav2.getTCData</td>
-</tr>
-<tr>
-<td>Callback:</td>
-<td>function(tcData: object, success: boolean)</td>
-</tr>
-<tr>
-<td>Parameter:</td>
-<td>not used</td>
-</tr>
-<tr>
-<td>Description</td>
-<td>Please note that this command is only used for downward compatibility. Developers should use the generic GPP command getSection or getField instead.<br></br>When called, the callback function will be called with the javascript representation of the parsed Core Segment (see above) and Publisher segment as tcData.</td>
-</tr>
-</table>
+This command is deprecated in TCF EU v2.2.
 
 
 

--- a/Sections/Section Information.md
+++ b/Sections/Section Information.md
@@ -9,6 +9,10 @@
 	  <td>Sept 28, 2022</td>    
     <td>Published final public version</td>
   </tr>
+	  <tr>
+	  <td>June, 2023</td>    
+    <td>Fixed Canada api name</td>
+  </tr>
   </table>
   
 ### Section IDs
@@ -43,7 +47,7 @@ Each section represents a unique privacy signal, usually a unique jurisdiction. 
       </tr>
   <tr>
     <td><code>5</code></td>
-    <td>tcfca</td>
+    <td>tcfcav1</td>
     <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/Canada">Canadian TCF section</a></td>
   </tr>
   <tr>
@@ -90,12 +94,12 @@ Each section represents a unique privacy signal, usually a unique jurisdiction. 
 
 ### Reusable Sub-Sections
 
-New privacy framework signals may start as reusable sub-sections in the GPP. Over time as they become more widely adopted, they may become sections with their own ID and referenced in the Header. Reusable sub-sections may be added to any section using the delimiter “.” (dot) to separate the sub-sections from each other. Details on a reusable sub-section, including whether it is available, required, or optional, for a specific section are included in each specific section’s documentation.
+New privacy framework signals may start as reusable sub-sections in the GPP. Over time as they become more widely adopted, they may become sections with their own ID and reference in the Header. Reusable sub-sections may be added to any section using the delimiter “.” (dot) to separate the sub-sections from each other. Details on a reusable sub-section, including whether it is available, required, or optional, for a specific section are included in each specific section’s documentation.
  
  
 In order to be included as a supported reusable sub-section, the signal must meet the following criteria: 
 
-- Be open designs
+- Be openly designed
 - Be widely understood and adopted
 - Have a clear interface for machines
 


### PR DESCRIPTION
_Open for public comment until May 26th, 2023_
**Changes in this PR to support GPP API v1.1**
- Removed direct return values from all commands
- Added callback support for all commands
- Updated addEventHandler command to return initial EventListener response through callback instead of return value
- Added success parameter to all callbacks
- Fixed 2 typos in the sample stub code
- Removed getGPPData command
- Add new values to the eventName property in the EventListener object
- Added new property in the pingReturn object with the same new values
- Updated getSection output to array of objects

**Changes in PR to support TCF 2.2:**
- Removal of legitimate interest for purposes 3-6
- Removed getTCData command