### PR TITLE
Formatting of the getSection API command

### DIFF
--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -458,8 +458,31 @@ For example, client can ask the CMP to get the IAB TCF CA v1.0 TCData:
 
 
 ```javascript
-__gpp('getSection', myFunction, "tcfcav1");
+__gpp('getSection', myFunction, "tcfca"); 
 ```
+Example value of data passed to the callback: 
+```javascript
+[
+ /* Core segment */
+ {
+  Version:1, 
+  Created: Date (Thu Apr 13 2023 18:07:12 GMT+0200),
+  LastUpdated: Date (Thu Apr 13 2023 18:07:12 GMT+0200),
+  CmpId: 31, 
+  CmpVersion: 123,
+  ConsentScreen: 5,
+  ...
+  }, 
+  /* Publisher Purposes Segment (optional) */
+ {
+  SegmentType:3, 
+  PubPurposesExpressConsent : [1,2,3,4,5],
+  PubPurposesImpliedConsent  : [6,7,8,9],
+  ...
+  } 
+ ]
+```
+
 A call to ` __gpp('getSection', null, "tcfeuv2");` will return `null`.
 ______
 #### `getField` <a name="getfield"></a>

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -424,7 +424,7 @@ __gpp('hasSection', myFunction, "tcfcav1");
 ______
 #### `getSection` <a name="getsection"></a>
 
-The `getSection` command can be used to receive the (parsed) representation of a section of a certain specification. The callback shall be called with the (parsed) representation as the argument for the data parameter. The parsed representation of a section is an array of objects, where each object represents one segment of this section in the order that is given by the section specification. For example, the data parameter for the TCF Canada will be an array with one or two objects (Core segment plus optional publisher purposes segment). Each object is composed of the fields defined by the section specification.
+The `getSection` command can be used to receive the (parsed) representation of a section of a certain specification. The callback shall be called with the (parsed) representation as the argument for the data parameter. The parsed representation of a section is an array of objects, where each object represents one sub-section of this section in the order that is given by the section specification. For example, the data parameter for the TCF Canada will be an array with one or two objects (Core sub-section plus optional publisher purposes sub-section). Each object is composed of the fields defined by the section specification.
 
 The data parameter may be `null` for sections that don't allow accessing the section data object outside an event handler. It may also be `null` when the CMP is not yet loaded.
 
@@ -464,7 +464,7 @@ __gpp('getSection', myFunction, "tcfcav1");
 Example value of data passed to the callback: 
 ```javascript
 [
- /* Core segment */
+ /* Core Sub-section */
  {
   Version:1, 
   Created: Date (Thu Apr 13 2023 18:07:12 GMT+0200),
@@ -474,9 +474,9 @@ Example value of data passed to the callback:
   ConsentScreen: 5,
   ...
   }, 
-  /* Publisher Purposes Segment (optional) */
+  /* Publisher Purposes Sub-section (optional) */
  {
-  SegmentType:3, 
+  subsectionType:3, 
   PubPurposesExpressConsent : [1,2,3,4,5],
   PubPurposesImpliedConsent  : [6,7,8,9],
   ...

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -415,10 +415,10 @@ The `hasSection` command can be used to detect if the CMP has generated a sectio
  
 Example:
 
-A client wants to ask the CMP if there is data for IAB TCF v2:
+A client wants to ask the CMP if there is data for IAB TCF CA v1.0:
 
 ```javascript
-__gpp('hasSection', myFunction, "tcfeuv2");
+__gpp('hasSection', myFunction, "tcfcav1");
 ```
 
 ______
@@ -459,7 +459,7 @@ For example, client can ask the CMP to get the IAB TCF CA v1.0 TCData:
 
 
 ```javascript
-__gpp('getSection', myFunction, "tcfca"); 
+__gpp('getSection', myFunction, "tcfcav1"); 
 ```
 Example value of data passed to the callback: 
 ```javascript
@@ -484,7 +484,7 @@ Example value of data passed to the callback:
  ]
 ```
 
-A call to ` __gpp('getSection', null, "tcfeuv2");` will return `null`.
+
 ______
 #### `getField` <a name="getfield"></a>
 
@@ -519,7 +519,7 @@ The `getField` command can be used to receive a specific field out of a certain 
 For example, a client can ask the CMP to get the last updated field from the IAB TCF CA v1.0 TCData. 
 
 ```javascript
-__gpp('getField', myFunction, "tcfca.LastUpdated");
+__gpp('getField', myFunction, "tcfcav1.LastUpdated");
 ```
 
 ### What are non-generic commands?
@@ -538,12 +538,12 @@ Parameter:   data type       or   “not used”
 A description of the command, what it does, what it’s meant for, when to use it and how.
 ```
 
-Using the IAB TCF v2.0 as an example, the `getVendorList`command would be defined as: 
+Using the IAB TCF CA v1.0 as an example, the `getVendorList`command would be defined as: 
 
 ```
 getVendorList
 
-Command:     iabtcfeuv2.getVendorList
+Command:     iabtcfcav1.getVendorList
 
 Callback:    function (gvl: GlobalVendorList, success: boolean)
 
@@ -552,7 +552,7 @@ Parameter:   (optional) int or string
 Calling with this command and a valid vendorListVersion parameter shall return a GlobalVendorList object to the callback function….
 ```
 
-In the example above, a call to` __gpp (‘iabtcfeuv2.getVendorList’,myfunction)` will be treated in the same way as a call to `__tcfapi(‘getVendorList’,2,myfunction)` by the CMP.
+In the example above, a call to` __gpp (‘iabtcfcav1.getVendorList’,myfunction)` will be treated in the same way as a call to `__tcfapi(‘getVendorList’,2,myfunction)` by the CMP.
 
 
 __________

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -424,8 +424,9 @@ __gpp('hasSection', myFunction, "tcfeuv2");
 ______
 #### `getSection` <a name="getsection"></a>
 
-The `getSection` command can be used to receive the (parsed) object representation of a section of a certain specification. 
-The callback shall be called with the (parsed) object representation as the argument for the `data` parameter. The `data` parameter may be `null` for sections that don't allow accessing the section data object outside an event handler.  It may also be `null` when the CMP is not yet loaded.
+The `getSection` command can be used to receive the (parsed) representation of a section of a certain specification. The callback shall be called with the (parsed) representation as the argument for the data parameter. The parsed representation of a section is an array of objects, where each object represents one segment of this section in the order that is given by the section specification. For example, the data parameter for the TCF Canada will be an array with one or two objects (Core segment plus optional publisher purposes segment). Each object is composed of the fields defined by the section specification.
+
+The data parameter may be `null` for sections that don't allow accessing the section data object outside an event handler. It may also be `null` when the CMP is not yet loaded.
 
 
 
@@ -443,7 +444,7 @@ The callback shall be called with the (parsed) object representation as the argu
   <tr>
     <td><code>callback</code></td>
     <td>function</td>
-    <td>function (data: object or null, success: boolean)</td>
+    <td>function (data: array of objects or null, success: boolean)</td>
   </tr>
   <tr>
     <td><code>parameter</code></td>
@@ -515,10 +516,10 @@ The `getField` command can be used to receive a specific field out of a certain 
 
 
 
-For example, a client can ask the CMP to get the last updated field from the IAB TCF v2.0 TCData. 
+For example, a client can ask the CMP to get the last updated field from the IAB TCF CA v1.0 TCData. 
 
 ```javascript
-__gpp('getField', myFunction, "tcfeuv2.LastUpdated");
+__gpp('getField', myFunction, "tcfca.LastUpdated");
 ```
 
 ### What are non-generic commands?


### PR DESCRIPTION
Addresses issue #47. Updated the output to be an array rather than an object and included example output. 