### PR TITLE
Fix Canada api name references in GPP 1.1

### DIFF
--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -849,7 +849,7 @@ Below are example key names from existing APIs. For a complete list of key names
      </tr>
   <tr>
 	  <td><code>IABGPP_TCFCA1_Version</code></td>    
-<td>IAB TCF CA v2 Version number (see  <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/Canada">IAB TCF CA v1 specification)</td>
+<td>IAB TCF CA v1 Version number (see  <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/Canada">IAB TCF CA v1 specification)</td>
    </tr>
   <tr>
 	  <td><code>IABGPP_TCFCA1_Created</code></td>    
@@ -992,7 +992,7 @@ window.__gpp_stub = function ()
     gppVersion        : '1.1',
     cmpStatus         : 'stub',
     cmpDisplayStatus  : 'hidden',
-    supportedAPIs     : ['tcfeuv2', 'tcfcav1', 'tcfva', 'usnat'],
+    supportedAPIs     : ['tcfeuv2', 'tcfcav1', 'usva', 'usnat'],
     cmpId             : 31,
     sectionList       : [],
     applicableSections: [-1], //or 0 or ID set by publisher

--- a/Sections/Canada/GPPExtension: IAB Canada TCF.md
+++ b/Sections/Canada/GPPExtension: IAB Canada TCF.md
@@ -17,7 +17,7 @@
 </tr>
 <tr>
 <td>Client side API prefix</td>
-<td>tcfca</td>
+<td>tcfcav1</td>
 <td>The IAB TCF Canada is registered with client side API prefix &ldquo;tcfcav1&rdquo; in the GPP Client Side API.</td>
 </tr>
 </tbody>

--- a/Sections/Section Information.md
+++ b/Sections/Section Information.md
@@ -9,6 +9,10 @@
 	  <td>Sept 28, 2022</td>    
     <td>Published final public version</td>
   </tr>
+	  <tr>
+	  <td>June, 2023</td>    
+    <td>Fixed Canada api name</td>
+  </tr>
   </table>
   
 ### Section IDs
@@ -43,7 +47,7 @@ Each section represents a unique privacy signal, usually a unique jurisdiction. 
       </tr>
   <tr>
     <td><code>5</code></td>
-    <td>tcfca</td>
+    <td>tcfcav1</td>
     <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/Canada">Canadian TCF section</a></td>
   </tr>
   <tr>
@@ -90,12 +94,12 @@ Each section represents a unique privacy signal, usually a unique jurisdiction. 
 
 ### Reusable Sub-Sections
 
-New privacy framework signals may start as reusable sub-sections in the GPP. Over time as they become more widely adopted, they may become sections with their own ID and referenced in the Header. Reusable sub-sections may be added to any section using the delimiter “.” (dot) to separate the sub-sections from each other. Details on a reusable sub-section, including whether it is available, required, or optional, for a specific section are included in each specific section’s documentation.
+New privacy framework signals may start as reusable sub-sections in the GPP. Over time as they become more widely adopted, they may become sections with their own ID and reference in the Header. Reusable sub-sections may be added to any section using the delimiter “.” (dot) to separate the sub-sections from each other. Details on a reusable sub-section, including whether it is available, required, or optional, for a specific section are included in each specific section’s documentation.
  
  
 In order to be included as a supported reusable sub-section, the signal must meet the following criteria: 
 
-- Be open designs
+- Be openly designed
 - Be widely understood and adopted
 - Have a clear interface for machines
 


### PR DESCRIPTION
A variety of places still have the wrong canada api name

Fixes #73 and Fixes #78