### PR TITLE
US privacy child consent clarifications

### DIFF
--- a/Sections/Section Information.md
+++ b/Sections/Section Information.md
@@ -58,32 +58,32 @@ Each section represents a unique privacy signal, usually a unique jurisdiction. 
   <tr>
     <td><code>7</code></td>
     <td>usnat</td>
-    <td>US - national section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-National">US - national section </a></td>
   </tr>
   <tr>
     <td><code>8</code></td>
     <td>usca</td>
-    <td>US - California section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/CA">US - California section </a></td>
      </tr>
   <tr>
     <td><code>9</code></td>
     <td>usva</td>
-    <td>US - Virginia section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/VA">US - Virginia section </a></td>
       </tr>
   <tr>
     <td><code>10</code></td>
     <td>usco</td>
-    <td>US - Colorado section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/CO">US - Colorado section </a></td>
   </tr>
   <tr>
     <td><code>11</code></td>
     <td>usut</td>
-    <td>US - Utah section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/UT">US - Utah section </a></td>
   </tr>
   <tr>
     <td><code>12</code></td>
     <td>usct</td>
-    <td>US - Connecticut section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/CT">US - Connecticut section </a></td>
      </td>
      </td>
   </tr>

--- a/Sections/US-National/IAB Privacy’s National Privacy Technical Specification.md
+++ b/Sections/US-National/IAB Privacy’s National Privacy Technical Specification.md
@@ -258,7 +258,8 @@
 <tr>
 <td>KnownChildSensitiveDataConsents</td>
 <td>N-Bitfield(2,2)</td>
-<td>Two bits for each Data Activity:<code>0</code>  The Business does not have actual knowledge that it Processes Personal Data or Sensitive Data of a Consumer who is under 16 years old.<p><code>1</code> No Consent<p><code>2</code> Consent&nbsp;
+<td>Two bits for each Data Activity:
+  <p></p><code>0</code> Not Applicable. The Business does not have actual knowledge that it Processes Personal Data or Sensitive Data of a Consumer who is under 17 years old.<p><code>1</code> No Consent<p><code>2</code> Consent&nbsp;
   <p>Data Activities:</p>
   <p>(1) Consumer Consent to Process the Consumer’s Personal Data or Sensitive Data for selling, sharing, or targeted advertising for a Consumer  between the age of 13 and 16.
   <p>References:

--- a/Sections/US-National/IAB Privacy’s National Privacy Technical Specification.md
+++ b/Sections/US-National/IAB Privacy’s National Privacy Technical Specification.md
@@ -24,7 +24,11 @@
 </div>
 
 <h2>US National Privacy Section</h2>
-<p style="text-align: justify;">The US National Privacy Section is a string that consists of the components described below. Users should employ the US National Privacy Section only if they will adhere to the National Approach for their processing of a consumer&rsquo;s personal data.</p>
+<p style="text-align: justify;">The US National Privacy Section is a string that consists of the components described below. The US National Privacy Section is intended to be used  for MSPA Covered Transactions.  The requirements for using the US National Privacy Section for MSPA Covered Transactions are defined by the MSPA “US National Approach” as a way to comply with the highest common denominator of all different state privacy law requirements in circumstances where the First Party setting the values for the string: (1) does not know the state residency of the Consumer; or (2) otherwise does not wish to use the Consumer’s specific state residency to differentiate how they will treat the Consumer for purposes of compliance with applicable state privacy laws.  Requirements for using the components of the US National Privacy Section relating to sensitive data and childrens’ data are not currently defined by the MSPA, but may be defined by a future amendment or addendum to the MSPA.</p> 
+
+<p>Notwithstanding that the US National Privacy Section is intended to be used in conjunction with the MSPA, those who use it for non-MSPA Covered Transactions are representing to recipients of the string whether they have complied with the specific state law requirements referenced in the description of each string component.</p>
+
+<p>The US National Privacy Section does not reflect any requirements of US federal law (for example, it does not reflect any COPPA consent requirements) and instead is intended only for use as a tool for compliance with applicable US state privacy law requirements.  </p>
 <h3>Summary</h3>
 <div>
 <table>
@@ -254,12 +258,16 @@
 <tr>
 <td>KnownChildSensitiveDataConsents</td>
 <td>N-Bitfield(2,2)</td>
-<td>Two bits for each Data Activity:<code>0</code>  Not Applicable. The Business does not have actual knowledge that it Processes Personal Data or Sensitive Data of a Consumer who is a known child.<p><code>1</code> No Consent<p><code>2</code> Consent&nbsp;<p>(1) Consent to Process the Consumer&rsquo;s Personal Data or Sensitive Data for Consumers from Age 13 to 16.<p><p>References:
-<ul>
-<li>Cal. Civ. Code Cal. Civ. Code 1798.120(c)</li>
-<li>Conn. PA 22-15, Sec. 6(a)(4)</li>
-</ul>
-(2) Consent to Process the Consumer&rsquo;s Personal Data or Sensitive Data for Consumers Younger Than 13 Years of Age.<p><p>References:
+<td>Two bits for each Data Activity:<code>0</code>  The Business does not have actual knowledge that it Processes Personal Data or Sensitive Data of a Consumer who is under 16 years old.<p><code>1</code> No Consent<p><code>2</code> Consent&nbsp;
+  <p>Data Activities:</p>
+  <p>(1) Consumer Consent to Process the Consumer’s Personal Data or Sensitive Data for selling, sharing, or targeted advertising for a Consumer  between the age of 13 and 16.
+  <p>References:
+    <ul>
+      <li>Cal. Civ. Code Cal. Civ. Code 1798.120(c)</li>
+      <li>Conn. PA 22-15, Sec. 6(a)(4)</li>
+    </ul>
+  <p></p>(2) Verifiable consent obtained from the Consumer’s parent or lawful guardian to Process the Personal Data or Sensitive Data of a Consumer Younger Than 13 Years of Age.
+<p><p>References:
 <ul>
 <li>Cal. Civ. Code Cal. Civ. Code 1798.120(c)</li>
 <li>Virginia Code 59.1-578(A)(5)</li>

--- a/Sections/US-States/CA/GPP Extension: IAB Privacy’s California Privacy Technical Specification.md
+++ b/Sections/US-States/CA/GPP Extension: IAB Privacy’s California Privacy Technical Specification.md
@@ -98,7 +98,7 @@
 <tr>
 <td style="text-align:left">KnownChildSensitiveDataConsents</td>
 <td style="text-align:left">N-Bitfield(2,2)</td>
-<td style="text-align:left">Two bits for each Data Activity:<p><code>0</code> Not Applicable. The Business does not have actual knowledge that it Processes Personal Information of Consumers Less Than 16 years of Age.<p><code>1</code> No Consent<p><code>2</code> Consent<p>Data Activities:<p>(1) Consent to Sell the Personal Information of Consumers Less Than 16 years of Age<p>(2) Consent to Share the Personal Information of Consumers Less Than 16 years of Age</td>
+<td style="text-align:left">Two bits for each Data Activity:<p><code>0</code> Not Applicable. The Business does not have actual knowledge that this transaction involves Processing the Personal Information of a Consumer who is Less Than 16 years of Age.<p><code>1</code> No Consent<p><code>2</code> Consent<p>Data Activities:<p>(1) Consent to Sell the Personal Information of Consumers Less Than 16 years of Age. For a Consumer the Business has actual knowledge is under 13 years of age, this must be consent given by the Consumer’s parent or guardian. For a Consumer the Business has actual knowledge is  between the ages of 13 and 16, this must be Consumer consent.<p>(2) Consent to Share the Personal Information of Consumers Less Than 16 years of Age. For a Consumer the Business has actual knowledge is under 13 years of age, this must be consent given by the Consumer’s parent of guardian. For a Consumer the Business has actual knowledge is between the ages of 13 and 16, this must be Consumer consent.</td>
 </tr>
 <tr>
 <td style="text-align:left">PersonalDataConsents</td>

--- a/Sections/US-States/CA/GPP Extension: IAB Privacy’s California Privacy Technical Specification.md
+++ b/Sections/US-States/CA/GPP Extension: IAB Privacy’s California Privacy Technical Specification.md
@@ -24,7 +24,7 @@
 
 
 <h2 id="california-privacy-section">California Privacy Section</h2>
-<p>The California Privacy Section consists of the components described below. Users should employ the California Privacy String only if they have determined the CPRA applies to their processing of a consumer&#39;s personal information.</p>
+<p>The California Privacy Section consists of the components described below. Users of the spec should employ the California Privacy String only if they have determined the CPRA applies to their processing of a consumer&#39;s personal information.</p>
 <h3 id="summary">Summary</h3>
 <table>
 <thead>

--- a/Sections/US-States/CO/GPP Extension: IAB Privacy’s Colorado Privacy Technical Specification.md
+++ b/Sections/US-States/CO/GPP Extension: IAB Privacy’s Colorado Privacy Technical Specification.md
@@ -95,7 +95,7 @@
 <tr>
 <td style="text-align:left">KnownChildSensitiveDataConsents</td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Consent to Process Sensitive Data from a Known Child.<p><code>0</code> Not Applicable. The Controller does not Process Sensitive Data of a known Child.<p><code>1</code> No Consent<p><code>2</code> Consent</td>
+<td style="text-align:left">Consent to Process Sensitive Data from a Known Child given by the Consumer’s parent or lawful guardian.<p><code>0</code> Not Applicable. The Controller does not Process Sensitive Data of a Known Child.<p><code>1</code> No Consent<p><code>2</code> Consent</td>
 </tr>
 <tr>
 <td style="text-align:left">MspaCoveredTransaction</td>

--- a/Sections/US-States/CO/GPP Extension: IAB Privacy’s Colorado Privacy Technical Specification.md
+++ b/Sections/US-States/CO/GPP Extension: IAB Privacy’s Colorado Privacy Technical Specification.md
@@ -22,7 +22,7 @@
 
 
 <h2 id="colorado-privacy-section">Colorado Privacy Section</h2>
-<p>The Colorado Privacy Section consists of the components described below. Users should employ the Colorado Privacy Section only if they have determined the CPA applies to their processing of a consumer&#39;s personal data.</p>
+<p>The Colorado Privacy Section consists of the components described below. Users of the spec should employ the Colorado Privacy Section only if they have determined the CPA applies to their processing of a consumer&#39;s personal data.</p>
 <h3 id="summary">Summary</h3>
 <table>
 <thead>

--- a/Sections/US-States/CT/GPP Extension: IAB Privacy’s Connecticut Privacy Technical Specification.md
+++ b/Sections/US-States/CT/GPP Extension: IAB Privacy’s Connecticut Privacy Technical Specification.md
@@ -22,7 +22,7 @@
 
 
 <h2 id="connecticut-privacy-section">Connecticut Privacy Section</h2>
-<p>The Connecticut Privacy Section consists of the components described below. Users should employ the Connecticut Privacy Section only if they have determined the CAPDP applies to their processing of a consumer&#39;s personal data.</p>
+<p>The Connecticut Privacy Section consists of the components described below. Users of the spec should employ the Connecticut Privacy Section only if they have determined the CAPDP applies to their processing of a consumer&#39;s personal data.</p>
 <h3 id="summary">Summary</h3>
 <table>
 <thead>

--- a/Sections/US-States/CT/GPP Extension: IAB Privacy’s Connecticut Privacy Technical Specification.md
+++ b/Sections/US-States/CT/GPP Extension: IAB Privacy’s Connecticut Privacy Technical Specification.md
@@ -95,7 +95,7 @@
 <tr>
 <td style="text-align:left">KnownChildSensitiveDataConsents</td>
 <td style="text-align:left">N-Bitfield(2,3)</td>
-<td style="text-align:left">Two bits for each Data Activity:<p><code>0</code> Not Applicable. The Controller does not Process Sensitive Data of a known Child.<p><code>1</code> No Consent<p><code>2</code> Consent<p>(1) Consent to Process Sensitive Data from a Known Child.<p>(2) Consent to Sell the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age.<p>(3) Consent to Process the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age for Purposes of Targeted Advertising.</td>
+<td style="text-align:left">Two bits for each Data Activity:<p><code>0</code> Not Applicable. The Controller does not Process Sensitive Data of a Consumer the Business has actual knowledge is less than 16 years old.<p><code>1</code> No Consent<p><code>2</code> Consent<p>(1) Verifiable parental consent to Process Sensitive Data from a Consumer the Business has actual knowledge is less than 13 years old.<p>(2) Consumer Consent to Sell the Consumer’s Personal Data for a Consumer at Least 13 Years of Age but Younger Than 16 Years of Age.<p>(3) Consumer Consent to Process the Consumer’s Personal Data for Purposes of Targeted Advertising for a Consumer At Least 13 Years of Age but Younger Than 16 Years of Age.</td>
 </tr>
 <tr>
 <td style="text-align:left">MspaCoveredTransaction</td>

--- a/Sections/US-States/UT/GPP Extension: IAB Privacy’s Utah Privacy Technical Specification.md
+++ b/Sections/US-States/UT/GPP Extension: IAB Privacy’s Utah Privacy Technical Specification.md
@@ -23,7 +23,7 @@
 
 
 <h2 id="utah-privacy-section">Utah Privacy Section</h2>
-<p>The Utah Privacy Section consists of the components described below. Users should employ the Utah Privacy Section only if they have determined the UCPA applies to their processing of a consumer&#39;s personal data.</p>
+<p>The Utah Privacy Section consists of the components described below. Users of the spec should employ the Utah Privacy Section only if they have determined the UCPA applies to their processing of a consumer&#39;s personal data.</p>
 <h3 id="summary">Summary</h3>
 <table>
 <thead>

--- a/Sections/US-States/UT/GPP Extension: IAB Privacy’s Utah Privacy Technical Specification.md
+++ b/Sections/US-States/UT/GPP Extension: IAB Privacy’s Utah Privacy Technical Specification.md
@@ -101,7 +101,7 @@
 <tr>
 <td style="text-align:left">KnownChildSensitiveDataConsents</td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Consent to Process Sensitive Data from a Known Child<p><code>0</code> Not Applicable. The Controller does not Process Sensitive Data of a known Child.<p><code>1</code> No Consent<p><code>2</code> Consent</td>
+<td style="text-align:left">Verifiable parental Consent to Process Sensitive Data of a Consumer the Business has actual knowledge is under 13 years old.<p><code>0</code> Not Applicable. The Controller does not have actual knowledge that it Process Sensitive Data of a Consumer it has actual knowledge is under 13 years old.<p><code>1</code> No Consent<p><code>2</code> Consent</td>
 </tr>
 <tr>
 <td style="text-align:left">MspaCoveredTransaction</td>


### PR DESCRIPTION
- Added clarifications to the descriptions of the values for KnownChildSensitiveDataConsents fields in the usnat, usca, usco, usct, and usut sections.
- Included hyperlinks for all US sections in Section Information
