### PR TITLE
Addition of CMP ID description and GPP Macro substitution clarification

### DIFF
--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -113,6 +113,18 @@ Requirements for the interface:
 
 All CMPs must support all generic commands. Generic commands are commands that can be used independent of [section specifications](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/SectionInformation.md). All generic commands must always be executed immediately without any asynchronous logic and call the supplied callback function immediately. The generic commands are: [‘ping’](#ping), [‘addEventListener’](#addeventlistener), [‘removeEventListener’](#removeeventlistener), [‘hasSection’](#hassection), [‘getSection’](#getsection), and [‘getField’](#getfield). 
 
+
+### What is CMP ID?
+
+
+Regional section policy writers may require CMPs to register to operate within the policies for that section. In these cases, CMP IDs must be used if the CMP has an ID. For CMPs that are not registered, a value of 1 must be used by string creators who do not have a CMP ID and are not using a commercially available CMP.
+
+**Examples:**
+
+Publisher A looking to create a GPP string that will contain the section for the US National approach must use 1 as value for CMP ID since the MSPA does not have CMP registration requirements.
+
+Publisher B looking to create a GPP string that will contain sections for the US National approach or the TCF EU must register themselves or work with a registered CMP and use the assigned CMP ID in accordance with the TCF Policies.
+
 ________
 #### `ping` <a name="ping"></a>
 
@@ -166,7 +178,7 @@ signalStatus : String, // possible values: not ready, ready
 
 supportedAPIs : Array of string, // list of supported APIs (section ids and prefix strings), e.g. used while loading. Example: ["2:tcfeuv2","6:uspv1"] 
 
-cmpId : Number, // IAB assigned CMP ID, may be 0 during stub/loading
+cmpId : Number, // IAB assigned CMP ID, may be 0 during stub/loading. Reference the above CMP ID section for additional information.
 
 sectionList : Array of Number, // may be empty during loading of the CMP
 

--- a/Core/Consent String Specification.md
+++ b/Core/Consent String Specification.md
@@ -700,14 +700,20 @@ Since the pixel is in an <img> tag without the ability to execute Javascript, th
 - `${GPP_STRING_XXXXX}` where `XXXXX` is the numeric GPP ID of the vendor receiving the string. - The applicable GPP Section ID must also be inserted, where the ${GPP_SID}macro is present.
 
 
-For example, for Vendor A with ID 123 to receive a GPP String which includes the EU TCF v2 as applicable section, an image URL must include two key-value pairs with the URL parameters and macros `gpp=${GPP_STRING_123}` and `gpp_sid=${GPP_SID}`.
+Vendors not registered to participate in any framework supported by the Global Privacy Platform (e.g. MSPA, TCF CA, TCF EU) may pass ${GPP_STRING} without the GPP ID. Vendors who are registered to participate and have a GPP ID must include it in the macro. When vendors that are callers–who have the option to expand on the macros–are deciding how to proceed with vendor callees not participating in a GPP supported framework (e.g. MSPA, TCF CA, TCF EU), vendors should reference each framework's policy.
 
+**Example when ${GPP_STRING} rather than ${GPP_STRING_XXXXX}may be used:**
 
-The resulting URL is: 
+The GPP String includes one of the US States sections or the US National section, but the string creator has indicated that the transaction is not covered by the MSPA. Vendors who do not participate in the MSPA may request the string, but may not have a GPP ID. In this case, ${GPP_STRING} may be used.
+
+**Example when ${GPP_STRING_XXXXX}is used:**
+
+Vendor A with ID 123 to receive a GPP String which includes the EU TCF v2 as applicable section, an image URL must include two key-value pairs with the URL parameters and macros `gpp=${GPP_STRING_123}` and `gpp_sid=${GPP_SID}`.
+
+- The resulting URL is: 
 `http://vendor-a.com/key1-val1&key2=val2&gpp=${GPP_STRING_123}&gpp_sid=${GPP_SID}`
 
-
-If the GPP String is: 
+- If the GPP String is: 
 `DBACNYA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA~1YNN`
 
 


### PR DESCRIPTION
Added the CMP ID information to explain how CMP IDs should be used based on CMP registration requirements.

Added clarification to the consent string spec on the use of the GPP ID and examples of including vs. excluding the ID. This is related to issue https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/issues/60