### PR TITLE
Consent string clarifications

### DIFF
--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -345,6 +345,144 @@ A call to the `addEventListener` command must always trigger an immediate call t
   </tr>
 </table>
 
+The “signalStatus” event shall always be the first (if applicable) and last in a chain of events being fired by the CMP. 
+A CMP **must** send all relevant events and it **must** send them in a specific order so that listeners (e.g. vendors) can understand when a task is completed. Whenever the CMP starts to change or is about to change any of the existing sections or is processing user input for an existing GPP string, it **must always** first set "signalStatus" to "not ready" and fire the corresponding event. It can then perform the tasks (e.g. change the sections along with firing the section change events). Only when all tasks are completed, the CMP can set the "signalStatus" to "ready" and fire the corresponding event.
+
+_Event Order Example 1_ 
+The following example illustrates the  events that are fired, and the other order in which they are fired, assuming support for IAB TCF Canada for a new user:
+<div>
+<table>
+<tbody>
+<tr>
+<td><strong>Event Order</strong></td>
+<td><strong>Event Name</strong></td>
+<td><strong>Data</strong></td>
+<td><strong>Description</strong></td>
+</tr>
+<tr>
+<td>1</td>
+<td colspan="3"><em>initial data of PingReturn is {gppVersion:1.1, cmpStatus: loading, cmpDisplayStatus: hidden, signalStatus: not ready, ...}</em></td>
+</tr>
+<tr>
+<td>2</td>
+<td>listenerRegistered</td>
+<td>&nbsp;</td>
+<td>CMP has registered the event listener. Event is immediately fired after registering.</td>
+</tr>
+<tr>
+<td>3</td>
+<td>cmpStatus</td>
+<td>loaded</td>
+<td>CMP is now loaded. Event is fired with name=cmpStatus and data=loaded.</td>
+</tr>
+<tr>
+<td>4</td>
+<td>cmpDisplayStatus</td>
+<td>visible</td>
+<td>CMP now displays the consent layer. Event is fired with name=cmpDisplayStatus and data = visible</td>
+</tr>
+<tr>
+<td>5</td>
+<td colspan="3"><em>User makes their choices and clicks on accept or reject or save</em></td>
+</tr>
+<tr>
+<td>6</td>
+<td>cmpDisplayStatus</td>
+<td>hidden</td>
+<td>CMP closed the consent layer and processes user input. Event is fired with name=cmpDisplayStatus and data=hidden</td>
+</tr>
+<tr>
+<td>7</td>
+<td>sectionChange</td>
+<td>tcfcav1</td>
+<td>CMP changes the section based on user input. Event is fired with name=sectionChange and data=tcfcav1 Note: if multiple sections are present, multiple sectionChange events may occur after another</td>
+</tr>
+<tr>
+<td>8</td>
+<td>signalStatus</td>
+<td>ready</td>
+<td>CMP is done with the processing, vendors can use the data. Event is fired with name=signalStatus and data = ready.</td>
+</tr>
+</tbody>
+</table>
+</div>
+
+_Event Order Example 2_ 
+The following example illustrates the events that are fired, and the order in which they are fired, assuming support for IAB TCF Canada for a returning user with a preexisting choice:
+<div>
+<table>
+<tbody>
+<tr>
+<td><strong>Event Order</strong></td>
+<td><strong>Event Name</strong></td>
+<td><strong>Data</strong></td>
+<td><strong>Description</strong></td>
+</tr>
+<tr>
+<td>1</td>
+<td colspan="3"><em>initial data of PingReturn is {gppVersion:1.1, cmpStatus: loading, cmpDisplayStatus: hidden, signalStatus: not ready, ... }</em></td>
+</tr>
+<tr>
+<td>2</td>
+<td>listenerRegistered</td>
+<td>&nbsp;</td>
+<td>CMP has registered the event listener. Event is immediately fired after registering.</td>
+</tr>
+<tr>
+<td>3</td>
+<td>cmpStatus</td>
+<td>loaded</td>
+<td>CMP is now loaded. Event is fired with name=cmpStatus and data=loaded</td>
+</tr>
+<tr>
+<td>4</td>
+<td>signalStatus</td>
+<td>ready</td>
+<td>CMP is done with the processing (consent information is loaded, no further processing needed, consent layer will not be shown), vendors can use the data. Event is fired with name=signalStatus and data=ready</td>
+</tr>
+<tr>
+<td>5</td>
+<td colspan="3"><em>User clicks on a link or button to resurface the consent layer in order to change their choice</em></td>
+</tr>
+<tr>
+<td>6</td>
+<td>signalStatus</td>
+<td>Not ready</td>
+<td>CMP is expecting changes, vendors should not use the data but wait and pause their processing. Event is fired with name=signalStatus and data=not ready</td>
+</tr>
+<tr>
+<td>7</td>
+<td>cmpDisplayStatus</td>
+<td>visible</td>
+<td>CMP now displays the consent layer. Event is fired with name=cmpDisplayStatus and data=visible</td>
+</tr>
+<tr>
+<td>8</td>
+<td colspan="3"><em>User makes their choices and clicks on accept or reject or save</em></td>
+<td>&nbsp;</td>
+<td>&nbsp;</td>
+</tr>
+<tr>
+<td>9</td>
+<td>cmpDisplayStatus</td>
+<td>hidden</td>
+<td>CMP closed the consent layer and processes user input. Event is fired with name=cmpDisplayStatus and data=hidden</td>
+</tr>
+<tr>
+<td>10</td>
+<td>sectionChange</td>
+<td>tcfcav1</td>
+<td>CMP changes the section based on user input. Event is fired with name=sectionChange and data=tcfcav1 Note: If multiple sections are present, multiple sectionChange events may occur after another</td>
+</tr>
+<tr>
+<td>11</td>
+<td>signalStatus</td>
+<td>ready</td>
+<td>CMP is done with the processing, vendors can use the data. Event is fired with name=signalStatus and data=ready</td>
+</tr>
+</tbody>
+</table>
+</div>
 ______
 #### `removeEventListener` <a name="removeeventlistener"></a>
 

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -418,7 +418,7 @@ Example:
 A client wants to ask the CMP if there is data for IAB TCF v2:
 
 ```javascript
-__gpp('hasSection', myFunction, "tcfeuv2");
+__gpp('hasSection', myFunction, "tcfcav1");
 ```
 
 ______
@@ -460,7 +460,6 @@ For example, client can ask the CMP to get the IAB TCF CA v1.0 TCData:
 ```javascript
 __gpp('getSection', myFunction, "tcfcav1");
 ```
-A call to ` __gpp('getSection', null, "tcfeuv2");` will return `null`.
 ______
 #### `getField` <a name="getfield"></a>
 
@@ -495,7 +494,7 @@ The `getField` command can be used to receive a specific field out of a certain 
 For example, a client can ask the CMP to get the last updated field from the IAB TCF v2.0 TCData. 
 
 ```javascript
-__gpp('getField', myFunction, "tcfeuv2.LastUpdated");
+__gpp('getField', myFunction, "tcfcav1.LastUpdated");
 ```
 
 ### What are non-generic commands?
@@ -519,7 +518,7 @@ Using the IAB TCF v2.0 as an example, the `getVendorList`command would be define
 ```
 getVendorList
 
-Command:     iabtcfeuv2.getVendorList
+Command:     iabtcfcav1.getVendorList
 
 Callback:    function (gvl: GlobalVendorList, success: boolean)
 
@@ -528,7 +527,7 @@ Parameter:   (optional) int or string
 Calling with this command and a valid vendorListVersion parameter shall return a GlobalVendorList object to the callback function….
 ```
 
-In the example above, a call to` __gpp (‘iabtcfeuv2.getVendorList’,myfunction)` will be treated in the same way as a call to `__tcfapi(‘getVendorList’,2,myfunction)` by the CMP.
+In the example above, a call to` __gpp (‘iabtcfcav1.getVendorList’,myfunction)` will be treated in the same way as a call to `__tcfapi(‘getVendorList’,2,myfunction)` by the CMP.
 
 
 __________
@@ -800,7 +799,7 @@ window.__gpp_stub = function ()
   gppVersion        : '1.1', // must be “Version.Subversion”, current: “1.1”
   cmpStatus         : 'stub', // possible values: stub, loading, loaded, error
   cmpDisplayStatus  : 'hidden', // possible values: hidden, visible, disabled
-  supportedAPIs     : ['tcfeuv2', 'tcfcav2', 'uspv1'], // list of supported APIs
+  supportedAPIs     : ['tcfeuv2', 'tcfcav1', 'uspv1'], // list of supported APIs
   cmpId             : 31, // IAB assigned CMP ID, may be 0 during stub/loading
   sectionList       : [],
   applicableSections: [-1], //or 0 or ID set by publisher
@@ -826,7 +825,7 @@ window.__gpp_stub = function ()
     gppVersion        : '1.1',
     cmpStatus         : 'stub',
     cmpDisplayStatus  : 'hidden',
-    supportedAPIs     : ['tcfeuv2', 'tcfva', 'usnat'],
+    supportedAPIs     : ['tcfeuv2', 'tcfcav1', 'tcfva', 'usnat'],
     cmpId             : 31,
     sectionList       : [],
     applicableSections: [-1], //or 0 or ID set by publisher
@@ -855,7 +854,7 @@ window.__gpp_stub = function ()
     gppVersion        : '1.1',
     cmpStatus         : 'stub',
     cmpDisplayStatus  : 'hidden',
-    supportedAPIs     : ['tcfeuv2', 'tcfva', 'usnat'],
+    supportedAPIs     : ['tcfeuv2', 'tcfeuv1', 'tcfva', 'usnat'],
     cmpId             : 31,
     sectionList       : [],
     applicableSections: [-1], //or 0 or ID set by publisher

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -346,10 +346,12 @@ A call to the `addEventListener` command must always trigger an immediate call t
 </table>
 
 The “signalStatus” event shall always be the first (if applicable) and last in a chain of events being fired by the CMP. 
+
 A CMP **must** send all relevant events and it **must** send them in a specific order so that listeners (e.g. vendors) can understand when a task is completed. Whenever the CMP starts to change or is about to change any of the existing sections or is processing user input for an existing GPP string, it **must always** first set "signalStatus" to "not ready" and fire the corresponding event. It can then perform the tasks (e.g. change the sections along with firing the section change events). Only when all tasks are completed, the CMP can set the "signalStatus" to "ready" and fire the corresponding event.
 
-_Event Order Example 1_ 
-The following example illustrates the  events that are fired, and the other order in which they are fired, assuming support for IAB TCF Canada for a new user:
+_Event Order Example 1:_ 
+
+The following example illustrates the  events that are fired, and the other order in which they are fired, assuming support for IAB TCF Canada for a new user.
 <div>
 <table>
 <tbody>
@@ -407,8 +409,9 @@ The following example illustrates the  events that are fired, and the other orde
 </table>
 </div>
 
-_Event Order Example 2_ 
-The following example illustrates the events that are fired, and the order in which they are fired, assuming support for IAB TCF Canada for a returning user with a preexisting choice:
+_Event Order Example 2:_ 
+
+The following example illustrates the events that are fired, and the order in which they are fired, assuming support for IAB TCF Canada for a returning user with a preexisting choice.
 <div>
 <table>
 <tbody>
@@ -483,7 +486,8 @@ The following example illustrates the events that are fired, and the order in wh
 </tbody>
 </table>
 </div>
-______
+
+___________
 #### `removeEventListener` <a name="removeeventlistener"></a>
 
 The `removeEventListener` command can be used to remove an existing event listener. The callback shall be called with `false` as the argument for the `data` parameter if the listener could not be removed (e.g. the CMP cannot find a registered listener corresponding to `listenerId`). A value of `false` will be passed as the argument to the `success` parameter if the CMP fails to process this command.

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -223,7 +223,7 @@ gppString: String // the complete encoded GPP string, may be empty during CMP lo
   <tr>
     <td><code>Null / not set</code></td>
     <td>cmpDisplayStatus</td>
-    <td>Is NULL when there is no display layer. Vendors should rely solely on signalStatus.</td>
+    <td>Is NULL when there is no display layer. Display layer refers to a modal that the user may interact with to express their choices. When no such modal is present, the value is NULL,  e.g. when there is only a Do Not Sell or Share Personal Data link on the page that when clicked does not launch a modal. In this example, vendors should rely solely on signalStatus and the cmpDisplayStatus will be NULL / not set.</td>
     </tr>
     <tr>
     <td><code>'not ready'</code></td>
@@ -233,7 +233,7 @@ gppString: String // the complete encoded GPP string, may be empty during CMP lo
   <tr>
     <td><code>'ready'</code></td>
     <td>signalStatus</td>
-    <td>The CMP is ready to respond to any calling scripts with the corresponding GPP string and applicable section ids.</td>
+    <td>The CMP is ready to respond to any calling scripts with the corresponding GPP string and applicable section ids. The ‘ready’ status should only be sent when the GPP string contains the section that is currently applicable with the user’s current choices reflected.  E.g. the ‘ready’ status should be signaled when applicableSection == -1 or applicableSection != 1 and the GPP string contains the section corresponding to applicableSection reflecting the user’s current choices.</td>
     </tr>
 </table>
 

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -911,7 +911,7 @@ if(__gpp)
  __gpp('addEventListener', function (evt)
  {
   //callback will receive all events, we only want to react on TCF canada events
-  if(evt.pingData.currentAPI !== 'tcfcav2'){return ;}
+  if(evt.pingData.currentAPI !== 'tcfcav1'){return ;}
 
   //react on changes or when the data is loaded
   if(
@@ -923,18 +923,18 @@ if(__gpp)
       evt.pingData.cmpDisplayStatus !== 'visible'
      )
      // optional additional/instead check:
-     // __gpp('hasSection', null, 'tcfcav2') === true
+     // __gpp('hasSection', null, 'tcfcav1') === true
     )
   {
-   var consentData =__gpp('getSection', null, 'tcfcav2');
+   var consentData =__gpp('getSection', null, 'tcfcav1');
    //will return the parsed IAB TCF Canada TCstring. All info is in there.	
 
    var vendorConsent = consentData.VendorExpressConsent; 
-   // equivalent to: __gpp('getField', null, 'tcfcav2.VendorExpressConsent');
+   // equivalent to: __gpp('getField', null, 'tcfcav1.VendorExpressConsent');
    var vendorImpConsent = consentData.VendorImpliedConsent;
-   // equivalent to: __gpp('getField', null, 'tcfcav2.VendorImpliedConsent');
+   // equivalent to: __gpp('getField', null, 'tcfcav1.VendorImpliedConsent');
    var purposeConsent = consentData.PurposesExpressConsent; 
-   // equivalent to: __gpp('getField', null, 'tcfcav2.PurposesExpressConsent');
+   // equivalent to: __gpp('getField', null, 'tcfcav1.PurposesExpressConsent');
    // ... do something Canadian !
   }
  });

--- a/Core/Consent String Specification.md
+++ b/Core/Consent String Specification.md
@@ -201,7 +201,7 @@ The following details provide information on creating, storing, and managing a G
 
 Note that neither the header nor the recommended encoding mechanism for a discrete section utilizes base64 encoding but rather a modified version of it. 
 
-#### Base64 Table from RFC 4648
+#### Table from RFC 4648
 <div>
 <table>
 <tbody>

--- a/Sections/EEA/GPPExtension: IAB Europe TCF.md
+++ b/Sections/EEA/GPPExtension: IAB Europe TCF.md
@@ -248,14 +248,6 @@ The publisher purposes segment is appended to the core segment by using the “.
 
 # Client side API
 
-The client side API does not expose the following custom GPP commands:
-
-## getTCData
-
-This command is deprecated in TCF EU v2.2.
-
-
-
 ## Key Names
 
 In the mobile or CTV context, the key names to be used in GPP are listed below. For complete details on the expected values for each key listed below, see the [IAB TCF EU v2 specification.](https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#what-is-the-cmp-in-app-internal-structure-for-the-defined-api)


### PR DESCRIPTION
- Additional guidance for regional policy writers on the naming convention for fields in their sections (Addresses #5) 
- Encoding clarifications, fixed incorrect headers in GPP String Examples 1 and 2 (Addresses #6,  #44,  #61) 
- Formatting updates