### PR TITLE
Update CMP API Specification.md

### DIFF
--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -1021,7 +1021,7 @@ window.__gpp_stub = function ()
   {
    if(__gpp.events[i].id == par)
    {
-    __gpp.events[i].splice(i,1);
+    __gpp.events.splice(i,1);
     success = true;
     break;
    }


### PR DESCRIPTION
__gpp.events[i].splice will throw error as it is not an array