### PR TITLE
Tcf canada v1.1 and GPP String v1.1

### DIFF
--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -813,6 +813,12 @@ Valid data types are Integer and String. All other data types such as Boolean, D
      </td>
      </td>
   </tr>
+  <tr>
+	<td><code>ArrayOfRanges<code></td>
+	<td>String</td>
+	<td><p>The key name will be combined by a static name and the key of the record. If the input data contains multiple records, the CMP SDK will create multiple keys, each with a combination of name and key.</p>
+	<p>The value consists of a sequence of "id:type"-pairs separated by underscore. E.g. "3:0_5:1_6:1_7:2_12:0"</p></td>	  
+  </tr>
  </table>
 
 

--- a/Core/Consent String Specification.md
+++ b/Core/Consent String Specification.md
@@ -594,68 +594,59 @@ In order to be backward compatible with IAB Europe’s TC String and US Privacy 
 
 A discrete section is encoded according to that specific section’s needs. This means today’s implementations that read and adapt to TCF v2.0 signals or US Privacy signals don't need to change their logic for a given discrete section of the string, as long as the implementation is aware of where the discrete section is.
 
-
 New sections should follow the guidelines below. Guidelines like these help developers quickly adopt new sections and allow for parsing new sections without the need to reinvent new data types.
 
-
 The possible data types are: 
-
 
 <table>
   <tr>
     <td><strong>Data Type</strong></td>
     <td><strong>Encoding</strong></td>
     <td><strong>JS API output</strong></td>
-    <td><strong>Description</strong></td>
-	  <td> </td>
+    <td><strong>Description</strong></td>	
   </tr>
   <tr>
     <td><code>Boolean</code></td>
     <td>1 bit</td>
     <td>true|false</td>
     <td>0=true, 1=false</td>
-	  <td></td>
   </tr>
   <tr>
     <td><code>Integer (fixed length of x)</code></td>
     <td>x bit</td>
     <td>Number</td>
     <td>A fixed amount of bit representing an integer. Usual lengths are 3, 6 or 12 bit. <br><br> Example: int(6) “000101” represents the number 5</td>
-	  <td></td>
   </tr>
   <tr>
     <td><code>Integer (Fibonacci)</code></td>
     <td>Variable Length</td>
     <td>Number</td>
     <td>Integer encoded using Fibonacci encoding <br><br> See <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#fibonacci-encoding-to-deal-with-string-length-"> “About Fibonacci Encoding” </a> for more detail</td>
-	  <td></td>
   </tr>
   <tr>
     <td><code>String (fixed length of x) (including country codes)</code></td>
     <td>x*6 bit</td>
     <td>String</td>
     <td>A fixed amount of bit representing a string. The character’s ASCII integer ID is subtracted by 65 and encoded into an int(6). <br><br>Example: int(6) “101010” represents integer 47 + 65 = char “h”</td>
-	  <td></td>
-</tr>
+  </tr>
   <tr>
     <td><code>Datetime</code></td>
     <td>36 bit</td>
     <td>Date</td>
     <td>A datetime is encoded as a 36 bit integer representing the 1/10th seconds since January 01 1970 00:00:00 UTC. <br><br>Example JavaScript representation: Math.round((new Date()).getTime()/100)</td>
-	  <td></td>
   </tr>
   <tr>
     <td><code>Bitfield (fixed length of x)</code></td>
     <td>x bit</td>
     <td>Array of Number</td>
     <td>A fixed amount of bit. Usually each bit represents a boolean for an ID within a group where the first bit corresponds to true/false for ID 1, the second bit corresponds to true/false for ID 2 and so on.</td>
-	  <td></td>
  </tr>
   <tr>
 	  <td><code>N-bitfield (Variable length Bitfield)</code></td>
 	  <td>variable</td>
 	  <td>Array of Number</td>
-	  <td>Consists of two datapoints: a fixed length Integer(16) that denotes the length and a bitfield with that specific length.<br></br>Please note: Although the API reads/writes to fields (length + bitfield), it will only output the IDs from the bitfield via JS APIs.</td>
+	  <td>Consists of two datapoints: a fixed length Integer(16) that denotes the length and a bitfield with that specific length.
+		<p>Please note: Although the API reads/writes to fields (length + bitfield), it will only output the IDs from the bitfield via JS APIs.</p></td>
 </tr>
   <tr>
     <td><code>Range (Int)</code></td>
@@ -682,7 +673,6 @@ The possible data types are:
 		    <li>Bits = 000000000010 0 0000000000000011 1 0000000000000101 0000000000001000</li>
 	    </ul> 
 Note: items may not be in sorted order.</td>
-	<td></td>
   </tr>
   <tr>
     <td><code>Range (Fibonacci)</code></td>
@@ -709,7 +699,6 @@ Note: items may not be in sorted order.</td>
 		    <li>Bits =  000000000010 0 0011 1 011 0011</li>
 	    </ul>
 Note: items MUST be in sorted order..</td>
-     <td></td>
   </tr>
   <tr>
 	<td><code>OptimizedRange</code></td>
@@ -736,6 +725,29 @@ Note: items MUST be in sorted order..</td>
 		</ul>
 		Note: This data type is used for downward compatibility only. OptimizedRange is the recommended data type to be used moving forward.</td>
 	</tr>	
+	<tr>
+		<td><code>ArrayOfRanges</code></td>
+		<td>variable</td>
+		<td>[{'key':number, 'type':number, 'ids':Array of number}, {...}, ...]</td>
+		<td>Consists of a variable amount of fields:
+			<p><ul><li>First field is always of type Int(12). The value indicates the number of records to follow.</li></p>
+				<li>Each entry consists of three datatypes:</li>
+				<ul><li>key - Int(6)</li>
+				<li>type - Int(2)</li>
+				<li>ids - <code>OptimizedIntRange </code>(uses Range(Int) for range of IDs, see <code>OptimizedIntRange</code> data type above for more details)</li></ul></ul>
+			<p>Note: <code>ArrayOfRanges</code> is used for downwards compatibility only.</p></td>
+	</tr>
+	<tr>
+		<td><code>N-ArrayOfRanges(X,Y)</code></td>
+		<td>variable</td>
+		<td>[{'key':number, 'type':number, 'ids':Array of number}, {...}, ...]</td>
+		<td>Consists of a variable amount of fields:
+			<p><ul><li>First field is always of type Int(12). The value indicates the number of records to follow.</li></p>
+				<li>Each record consists of three datatypes:</li>
+				<ul><li><b>key</b> - Int(X) Where X is given by the field definition within the corresponding specification.</li>
+				<li><b>type</b> - Int(Y) Where Y is given by the field definition within the corresponding specification.</li>
+				<li><b>ids</b> - <code>OptimizedRange </code>(uses Fibonacci coding for range of IDs, see <code>OptimizedRange</code> data type above for more details)</li></ul></ul></td></td>
+	</tr>
  </table>
  
  

--- a/Core/README.md
+++ b/Core/README.md
@@ -1,7 +1,7 @@
 # Global Privacy Platform
 
 
-Hosted in this repository are the technical specifications for the IAB Global Privacy Platform (GPP). The relevant specifications are: 
+Hosted in this repository are the technical specifications for the IAB Global Privacy Platform (GPP). The relevant specifications: 
 
 - Global Privacy Platform String
 - Consent Management API

--- a/Sections/Canada/GPPExtension: IAB Canada TCF.md
+++ b/Sections/Canada/GPPExtension: IAB Canada TCF.md
@@ -18,28 +18,22 @@
 <tr>
 <td>Client side API prefix</td>
 <td>tcfcav1</td>
-<td>The IAB TCF Canada is registered with client side API prefix &ldquo;tcfcav1&rdquo; in the GPP Client Side API.</td>
+<td>The IAB TCF Canada is registered with client side API prefix "tcfcav1" in the GPP Client Side API.</td>
 </tr>
 </tbody>
 </table>
 </div>
 <h2>Section encoding</h2>
-<p>The IAB TCF Canada will be using the following encoding for the GPP section. If already familiar with the IAB TCF Europe encoding, you may view the detailed differences between the two on the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/Canada/TCF%20EU%20TCF%20CA%20Comparison.md" target="_blank" rel="noopener">IAB Europe TCF with IAB Canada TCF Signal Definition</a> documentation.&nbsp;</p>
-<h3>Core segment</h3>
-<p>The core segment must always be present. It consists of the following fields:</p>
+<p>The IAB TCF Canada will be using the following encoding for the GPP section. If already familiar with the IAB TCF Europe encoding, you may view the detailed differences between the two on the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/Canada/TCF%20EU%20TCF%20CA%20Comparison.md" target="_blank" rel="noopener">IAB Europe TCF with IAB Canada TCF Signal Definition</a> documentation.</p>
+<h3>Core sub-section</h3>
+<p>The core sub-section must always be present. It consists of the following fields:</p>
 <div>
 <table>
 <thead>
 <tr>
-<th>
-<p><strong>Field name</strong></p>
-</th>
-<th>
-<p><strong>GPP Field Type</strong></p>
-</th>
-<th>
-<p><strong>Description</strong></p>
-</th>
+<th>Field name</th>
+<th>GPP Field Type</th>
+<th>Description</th>
 </tr>
 </thead>
 <tbody>
@@ -76,72 +70,108 @@
 <tr>
 <td>ConsentLanguage</td>
 <td>String(2)</td>
-<td>Two-letter<a href="https://en.wikipedia.org/wiki/ISO_639-1" target="_blank" rel="noopener">ISO 639-1</a> language code in which the CMP UI was presented&nbsp;</td>
+<td>Two-letter <a href="https://en.wikipedia.org/wiki/ISO_639-1" target="_blank" rel="noopener">ISO 639-1</a> language code in which the CMP UI was presented&nbsp;</td>
 </tr>
 <tr>
 <td>VendorListVersion</td>
 <td>Int(12)</td>
-<td>Version of the<a href="https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list" target="_blank" rel="noopener">GVL</a> used to create this TC String. Number corresponds to<a href="https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list" target="_blank" rel="noopener">GVL</a> vendorListVersion</td>
+<td>Version of the <a href="https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list" target="_blank" rel="noopener">GVL</a> used to create this TC String. Number corresponds to <a href="https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list" target="_blank" rel="noopener">GVL</a> vendorListVersion</td>
 </tr>
 <tr>
 <td>TcfPolicyVersion</td>
 <td>Int(6)</td>
-<td>Version of policy used within<a href="https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list" target="_blank" rel="noopener">GVL</a>. From the corresponding field in the<a href="https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list" target="_blank" rel="noopener">GVL</a> that was used for obtaining consent. A new policy version invalidates existing strings and requires CMPs to re-establish transparency and consent from users.&nbsp;</td>
+<td>Version of policy used within <a href="https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list" target="_blank" rel="noopener">GVL</a>. From the corresponding field in the <a href="https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list" target="_blank" rel="noopener">GVL</a> that was used for obtaining consent. A new policy version invalidates existing strings and requires CMPs to re-establish transparency and consent from users.&nbsp;</td>
 </tr>
 <tr>
 <td>UseNonStandardStacks</td>
 <td>Boolean</td>
-<td>1 CMP used non-IAB standard stacks during consent gathering0 IAB standard stacks were used Setting this to 1 means that a publisher-run CMP &ndash; that is still IAB Europe registered &ndash; is using customized Stack descriptions and not the standard stack descriptions defined in the<a href="https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/" target="_blank" rel="noopener">Policies</a> (Appendix A section E). A CMP that services multiple publishers sets this value to 0.&nbsp;</td>
+<td><code>1</code> CMP used non-IAB standard stacks during consent gathering
+  <p><code>0</code> IAB standard stacks were used</p> 
+    <p>Setting this to 1 means that a publisher-run CMP - that is still IAB Canada registered - is using customized Stack descriptions and not the standard stack descriptions defined in the <a href="https://iabcanada.com/tcf-policies/" target="_blank" rel="noopener">Policies</a> (Appendix A section E). A CMP that services multiple publishers sets this value to 0.</p></td>
 </tr>
 <tr>
-<td>SpecialFeatureExpressConsent&nbsp;</td>
+<td>SpecialFeatureExpressConsent</td>
 <td>Bitfield(12)</td>
-<td>One bit for each Special Feature:1 Opted in (express consent)0 Not opted in (no express consent) The TCF<a href="https://iabeurope.eu/iab-europe-transparency-consent-framework-policies/" target="_blank" rel="noopener">Policies</a> designates certain Features as &ldquo;special&rdquo; which means a CMP must afford the user a means to expressly consent to their use. These &ldquo;Special Features&rdquo; are published and numerically identified in the<a href="https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list" target="_blank" rel="noopener">Global Vendor List</a> separately from normal Features.&nbsp;</td>
+<td>One bit for each Special Feature:
+  <p><code>1</code> Opted in (express consent)</p>
+  <p><code>0</code> Not opted in (no express consent)</p> 
+  <p>The TCF <a href="https://iabcanada.com/tcf-policies/" target="_blank" rel="noopener">Policies</a> designates certain Features as "special" which means a CMP must afford the user a means to expressly consent to their use. These "Special Features" are published and numerically identified in the <a href="https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list" target="_blank" rel="noopener">Global Vendor List</a> separately from normal Features.</p></td>
 </tr>
 <tr>
-<td>PurposesExpressConsent&nbsp;</td>
+<td>PurposesExpressConsent</td>
 <td>Bitfield(24)</td>
-<td>One bit for each Purpose:1 Express Consent0 No Express Consent The user&rsquo;s consent value for each Purpose established on the legal basis of consent.The Purposes are numerically identified and published in the<a href="https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list" target="_blank" rel="noopener">Global Vendor List</a>. From left to right, Purpose 1 maps to the 0th bit, purpose 24 maps to the bit at index 23. Special Purposes are a different ID space and not included in this field. Note that purpose 1 bit is not used in TCF Canada.</td>
+<td>One bit for each Purpose:
+  <p><code>1</code> Express Consent</p>
+  <p><code>0</code> No Express Consent</p> 
+  <p>The user's consent value for each Purpose established on the legal basis of consent.The Purposes are numerically identified and published in the <a href="https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list" target="_blank" rel="noopener">Global Vendor List</a>. From left to right, Purpose 1 maps to the 0th bit, purpose 24 maps to the bit at index 23. Special Purposes are a different ID space and not included in this field. Note that purpose 1 bit is not used in TCF Canada.</p></td>
 </tr>
 <tr>
-<td>PurposesImpliedConsent&nbsp;</td>
+<td>PurposesImpliedConsent</td>
 <td>Bitfield(24)</td>
-<td>One bit for each Purpose:1 implied consent established0 implied consent was <strong>NOT</strong> established or it was established but user exercised an Objection to the Purpose The Purpose&rsquo;s transparency requirements are met for each Purpose on the legal basis of implied consent and the user has not exercised an Objection to that Purpose.By default or if the user has exercised an Objection to a Purpose, the corresponding bit for that Purpose is set to 0. From left to right, Purpose 1 maps to the 0th bit, purpose 24 maps to the bit at index 23. Special Purposes are a different ID space and not included in this field. Note that purpose 1 bit is not used in TCF Canada.</td>
+<td>One bit for each Purpose:
+<p><code>1</code> implied consent established</p>
+<p><code>0</code> implied consent was <strong>NOT</strong> established or it was established but user exercised an Objection to the Purpose</p> 
+<p>The Purpose's transparency requirements are met for each Purpose on the legal basis of implied consent and the user has not exercised an Objection to that Purpose.</p> 
+<p>By default or if the user has exercised an Objection to a Purpose, the corresponding bit for that Purpose is set to 0. From left to right, Purpose 1 maps to the 0th bit, purpose 24 maps to the bit at index 23. Special Purposes are a different ID space and not included in this field. Note that purpose 1 bit is not used in TCF Canada.</p></td>
 </tr>
 <tr>
 <td>VendorExpressConsent</td>
 <td>OptimizedRange</td>
-<td>List of Vendor IDs that indicate Consent for these vendors. Please note that the field is composed of several fields in order to store the data in GPP string format. The client side API format is array of int.&nbsp;</td>
+<td>List of Vendor IDs that indicate Consent for these vendors. Please note that the field is composed of several fields in order to store the data in GPP string format. The client side API format is array of int.</td>
 </tr>
 <tr>
-<td>VendorImpliedConsent&nbsp;</td>
+<td>VendorImpliedConsent</td>
 <td>OptimizedRange</td>
-<td>List of Vendor IDs for which Implied consent is established and the user did not exercise an Objection.. Please note that the field is composed of several fields in order to store the data in GPP string format. The client side API format is array of int.&nbsp;</td>
+<td>List of Vendor IDs for which Implied consent is established and the user did not exercise an Objection.. Please note that the field is composed of several fields in order to store the data in GPP string format. The client side API format is array of int.</td>
 </tr>
+<tr>
+<td>PubRestrictions</td>
+<td>N-ArrayOfRanges (6,2)</td>
+<td><p></p><b>Key:</b> The Vendor’s declared Purpose ID that the Publisher has indicated they are overriding.</p>
+    <p><b>Types:</b></p>
+    <p><code>0</code> Purpose Flatly Not Allowed by Publisher (regardless of Vendor declarations)</p>
+    <p><code>1</code> Require Express Consent (if Vendor has declared the Purpose IDs legal basis as Implied Consent and flexible)</p>
+    <p><code>2</code> Require Implied Consent (if Vendor has declared the Purpose IDs legal basis as Express Consent and flexible)</p>
+    <p><code>3</code> UNDEFINED (not used)</li></p>
+  <p><b>ids</b> - A single or range of Vendor ID(s) who the publisher has designated as restricted under the purpose id.</p>
+</tr>  
 </tbody>
 </table>
 </div>
-<p><strong>Note: </strong>Fields marked with * are only included in the string encoded version of the GPP segment but will not be returned by the client side API. Instead the client side API will return an array of int with the corresponding IDs.</p>
-<h3>Publisher Purposes Segment</h3>
-<p>The publisher purposes segment is appended to the core segment by using the &ldquo;.&rdquo; (dot) delimiter. The segment is optional. The segment fields are:</p>
+<h3>Disclosed Vendors Sub-section</h3>
+    <p>The disclosed vendors sub-section is appended to the core sub-section by using the “.” (dot) delimiter. This is an optional string sub-section. It may be used by a CMP while storing strings, but must not be included in the string when returned by the CMP API. The sub-section fields are:</p> 
+<div>
+  <table>
+    <thead><tr><th>Field name</th>
+      <th>GPP Field Type</th>
+      <th>Description</th>
+    </tr></thead>
+    <tbody>
+      <tr>
+        <td>SubsectionType</td>
+        <td>Int(3)</td>
+        <td>Always set to 1</td>
+      </tr>
+      <tr>
+        <td>DisclosedVendors</td>
+        <td>OptimizedRange</td>
+        <td>List of Vendor IDs that were disclosed in a CMP UI to the user</td>
+      </tr>
+    </tbody></table></div>
+<h3>Publisher Purposes Sub-section</h3>
+<p>The publisher purposes sub-section is appended to the core sub-section by using the &ldquo;.&rdquo; (dot) delimiter. The sub-section is optional. The sub-section fields are:</p>
 <div>
 <table>
 <thead>
 <tr>
-<th>
-<p><strong>Field name</strong></p>
-</th>
-<th>
-<p><strong>GPP Field Type</strong></p>
-</th>
-<th>
-<p><strong>Description</strong></p>
-</th>
+<th>Field name</th>
+<th>GPP Field Type</th>
+<th>Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>SegmentType</td>
+<td>SubsectionType</td>
 <td>Int(3)</td>
 <td>Always set to 3.</td>
 </tr>
@@ -175,7 +205,8 @@
 </div>
 <h2>Client side API</h2>
 <h3>Key Names</h3>
-<p>In the mobile or CTV context, the key names to be used in GPP are listed below.&nbsp;</p>
+<p>In the mobile or CTV context, the key names must follow the the naming conventions defined in the In-App Key Names portion of the GPP API Specification. The in-app values should also follow what is defined in the In-App Key Names portion of the specification and be transformed accordingly (for example, a field that has a data type of OptimizedRange will be converted to a string with an underscore used to separate each value).</p>
+<p>Below are some examples of the key names for TCF Canada. </p>
 <div>
 <table>
 <tbody>
@@ -184,60 +215,37 @@
 <td><strong>Value(s)</strong></td>
 </tr>
 <tr>
-<td><span style="color: #24292f;">IABGPP_TCFCA_CmpSdkID</span></td>
-<td>Number: The unsigned integer ID of CMP SDK</td>
+<td><code>IABGPP_TCFCAV1_CmpId</code></td>
+<td><b>Number:</b> The unsigned integer ID of CMP SDK</td>
 </tr>
 <tr>
-<td><span style="color: #24292f;">IABGPP_TCFCA_CmpSdkVersion</span></td>
-<td>Number: The unsigned integer version number of CMP SDK</td>
+<td><code>IABGPP_TCFCAV1_CmpVersion</code></td>
+<td><b>Number:</b> The unsigned integer version number of CMP SDK</td>
 </tr>
 <tr>
-<td><span style="color: #24292f;">IABGPP_TCFCA_PolicyVersion</span></td>
-<td>Number: The unsigned integer representing the version of the TCF that these consents adhere to.</td>
+<td><code>IABGPP_TCFCAV1_TcfPolicyVersion</code></td>
+<td><b>Number:</b> The unsigned integer representing the version of the TCF that these consents adhere to.</td>
 </tr>
 <tr>
-<td><span style="color: #24292f;">IABGPP_TCFCA_UseNonStandardStacks</span></td>
-<td>Number:1 - CMP used a non-standard stack0 - CMP did not use a non-sta<span style="color: #24292f;">ndard stack</span></td>
+<td><code">IABGPP_TCFCAV1_UseNonStandardStacks</code></td>
+<td><b>Number:</b> 1 - CMP used a non-standard stack; 0 - CMP did not use a non-standard stack</td>
 </tr>
 <tr>
-<td><span style="color: #24292f;">IABGPP_5_TCString</span></td>
-<td>String: Full encoded TC string</td>
+<td><code>IABGPP_5_TCString</code></td>
+<td><b>String:</b> Full encoded TC string</td>
 </tr>
 <tr>
-<td><span style="color: #24292f;">IABGPP_TCFCA_VendorExpressConsents</span></td>
-<td>Binary String: The '0' or '1' at position n &ndash; where n's indexing begins at 0 &ndash; indicates the consent status for Vendor ID n+1; false and true respectively. eg. '1' at index 0 is consent true for vendor ID 1</td>
+<td><code>IABGPP_TCFCAV1_VendorExpressConsents</code></td>
+<td><b>String:</b> Per the field description above, this is an array of integers that represent the list of Vendor IDs that indicate consent for these vendors. Since the data type for this field is OptimizedRange, the value for this should be a string (e.g. “1_4_99”). See In-App Key Names section of the GPP API Specification for more details.</td>
 </tr>
 <tr>
-<td><span style="color: #24292f;">IABGPP_TCFCA_VendorImpliedConsents</span></td>
-<td>Binary String: The '0' or '1' at position n &ndash; where n's indexing begins at 0 &ndash; indicates the legitimate interest status for Vendor ID n+1; false and true respectively. eg. '1' at index 0 is legitimate interest established true for vendor ID 1</td>
+<td><code>IABGPP_TCFCAV1_PubRestrictions</code></td>
+<td><b>String:</b> Per the field description above, this is a sequence of id:type pairs representing the Vendor IDs who the publisher has designated as restricted under the purpose id and the type of restriction.
+
+<p>Since the data type for this field is N-ArrayofRanges, the value for this should be a string (e.g. "3:0_5:1_6:1_7:2_12:0"). See In-App Key Names section of the GPP API Specification for more details.</p></td>
 </tr>
-<tr>
-<td><span style="color: #24292f;">IABGPP_TCFCA_PurposeExpressConsents</span></td>
-<td>Binary String: The '0' or '1' at position n &ndash; where n's indexing begins at 0 &ndash; indicates the consent status for purpose ID n+1; false and true respectively. eg. '1' at index 0 is legitimate interest established true for purpose ID 1</td>
-</tr>
-<tr>
-<td><span style="color: #24292f;">IABGPP_TCFCA_PurposeImpliedConsents</span></td>
-<td>Binary String: The '0' or '1' at position n &ndash; where n's indexing begins at 0 &ndash; indicates the legitimate interest status for purpose ID n+1; false and true respectively. eg. '1' at index 0 is legitimate interest established true for purpose ID 1</td>
-</tr>
-<tr>
-<td><span style="color: #24292f;">IABGPP_TCFCA_SpecialFeaturesExpressConsents</span></td>
-<td>Binary String: The '0' or '1' at position n &ndash; where n's indexing begins at 0 &ndash; indicates the opt-in status for special feature ID n+1; false and true respectively. eg. '1' at index 0 is opt-in true for special feature ID 1</td>
-</tr>
-<tr>
-<td><span style="color: #24292f;">IABGPP_TCFCA_PublisherExpressConsent</span></td>
-<td><span style="color: #24292f;">Binary String</span><span style="color: #24292f;">: The </span><span style="color: #24292f;">'0'</span><span style="color: #24292f;"> or </span><span style="color: #24292f;">'1'</span><span style="color: #24292f;"> at position n &ndash; where n's indexing begins at </span><span style="color: #24292f;">0</span><span style="color: #24292f;"> &ndash; indicates the purpose consent status for purpose ID n+1 for the publisher as they correspond to the </span><a href="https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#what-is-the-global-vendor-list" target="_blank" rel="noopener">Global Vendor List</a><span style="color: #24292f;"> Purposes; </span><span style="color: #24292f;">false</span><span style="color: #24292f;"> and </span><span style="color: #24292f;">true</span><span style="color: #24292f;"> respectively. eg. </span><span style="color: #24292f;">'1'</span><span style="color: #24292f;"> at index </span><span style="color: #24292f;">0</span><span style="color: #24292f;"> is consent </span><span style="color: #24292f;">true</span><span style="color: #24292f;"> for purpose ID </span><span style="color: #24292f;">1</span></td>
-</tr>
-<tr>
-<td><span style="color: #24292f;">IABGPP_TCFCA_PublisherImpliedConsent</span></td>
-<td>Binary String: The '0' or '1' at position n &ndash; where n's indexing begins at 0 &ndash; indicates the purpose legitimate interest status for purpose ID n+1 for the publisher as they correspond to the <a href="https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#what-is-the-global-vendor-list" target="_blank" rel="noopener">Global Vendor List</a> Purposes; false and true respectively. eg. '1' at index 0 is legitimate interest established true for purpose ID 1</td>
-</tr>
-<tr>
-<td><span style="color: #24292f;">IABGPP_TCFCA_PublisherCustomPurposesExpressConsents</span></td>
-<td>Binary String: The '0' or '1' at position n &ndash; where n's indexing begins at 0 &ndash; indicates the purpose consent status for the publisher's custom purpose ID n+1 for the publisher; false and true respectively. eg. '1' at index 0 is consent true for custom purpose ID 1</td>
-</tr>
-<tr>
-<td><span style="color: #24292f;">IABGPP_TCFCA_PublisherCustomPurposesImpliedConsents</span></td>
-<td>Binary String: The '0' or '1' at position n &ndash; where n's indexing begins at 0 &ndash; indicates the purpose legitimate interest status for the publisher's custom purpose ID n+1 for the publisher; false and true respectively. eg. '1' at index 0 is legitimate interest established true for custom purpose ID 1</td>
+<td><code>IABGPP_TCFCAV1_PublisherExpressConsent</code></td>
+<td><b>Binary String:</b> The'0' or '1' at position n &ndash; where n's indexing begins at 0 &ndash; indicates the purpose consent status for purpose ID n+1 for the publisher as they correspond to the <a href="https://github.com/patrickverdon/GDPR-Transparency-and-Consent-Framework/blob/TCF-Canada/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#what-is-the-global-vendor-list" target="_blank" rel="noopener">Global Vendor List</a> Purposes; false and true respectively. eg. '1' at index 0 is consent true for purpose ID 1</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
**These updates to the TCF Canada section and GPP String are available for public comment until March 13th, 2024.**

Updates made to properly support TCF Canada. 
- In TCF Canada section specification, added PubRestrictions to core sub-section and added Disclosed Vendors sub-sections
- In GPP API specification, added ArrayOfRanges input data type
- In GPP Consent String specification, added ArrayOfRanges and N-ArrayOfRanges(X,Y) data type