### PR TITLE
Updates & cleanup to existing US State sections regarding "IAB Privacy" language

### DIFF
--- a/Sections/US-States/CA/GPP Extension: California Privacy Technical Specification.md
+++ b/Sections/US-States/CA/GPP Extension: California Privacy Technical Specification.md
@@ -1,4 +1,4 @@
-<h1 id="gpp-extension-iab-privacy-s-california-privacy-technical-specification">GPP Extension: California Privacy Technical Specification</h1>
+<h1 id="gpp-extension-california-privacy-technical-specification">GPP Extension: California Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
 <p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the California section of the GPP specification by those who (i) are Signatories to IAB Privacy, Inc.’s <a href=https://www.iabprivacy.com/>Multi-State Privacy Agreement (MSPA)</a>; and (ii) those who are not signatories of the MSPA.</p>
 

--- a/Sections/US-States/CA/GPP Extension: IAB Privacy’s California Privacy Technical Specification.md
+++ b/Sections/US-States/CA/GPP Extension: IAB Privacy’s California Privacy Technical Specification.md
@@ -1,6 +1,7 @@
-<h1 id="gpp-extension-iab-privacy-s-california-privacy-technical-specification">GPP Extension: IAB Privacy’s California Privacy Technical Specification</h1>
+<h1 id="gpp-extension-iab-privacy-s-california-privacy-technical-specification">GPP Extension: California Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the GPP specifications with the IAB Privacy Multi-State Privacy Agreement legal requirements.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the California section of the GPP specification by those who (i) are Signatories to IAB Privacy, Inc.’s <a href=https://www.iabprivacy.com/>Multi-State Privacy Agreement (MSPA)</a>; and (ii) those who are not signatories of the MSPA.</p>
+
 
 <h3>Version History&nbsp;</h3>
 <div>

--- a/Sections/US-States/CA/README.md
+++ b/Sections/US-States/CA/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s California Privacy Technical Specification
+# California Privacy Technical Specification
 
 
  

--- a/Sections/US-States/CO/GPP Extension: Colorado Privacy Technical Specification.md
+++ b/Sections/US-States/CO/GPP Extension: Colorado Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-iab-privacy-s-colorado-privacy-technical-specification">GPP Extension: IAB Privacy’s Colorado Privacy Technical Specification</h1>
+<h1 id="gpp-extension-colorado-privacy-technical-specification">GPP Extension: Colorado Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the GPP specifications with the IAB Privacy Multi-State Privacy Agreement legal requirements.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Colorado section of the GPP specification by those who (i) are Signatories to IAB Privacy, Inc.’s <a href=https://www.iabprivacy.com/>Multi-State Privacy Agreement (MSPA)</a>; and (ii) those who are not signatories of the MSPA.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>

--- a/Sections/US-States/CO/README.md
+++ b/Sections/US-States/CO/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s Colorado Privacy Technical Specification
+# Colorado Privacy Technical Specification
 
 
 

--- a/Sections/US-States/CT/GPP Extension: Connecticut Privacy Technical Specification.md
+++ b/Sections/US-States/CT/GPP Extension: Connecticut Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-iab-privacy-s-connecticut-privacy-technical-specification">GPP Extension: IAB Privacy’s Connecticut Privacy Technical Specification</h1>
+<h1 id="gpp-extension-connecticut-privacy-technical-specification">GPP Extension: Connecticut Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the GPP specifications with the IAB Privacy Multi-State Privacy Agreement legal requirements.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Connecticut section of the GPP specification by those who (i) are Signatories to IAB Privacy, Inc.’s <a href=https://www.iabprivacy.com/>Multi-State Privacy Agreement (MSPA)</a>; and (ii) those who are not signatories of the MSPA.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>

--- a/Sections/US-States/CT/README.md
+++ b/Sections/US-States/CT/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s Connecticut Privacy Technical Specification
+# Connecticut Privacy Technical Specification
 
 
 

--- a/Sections/US-States/README.md
+++ b/Sections/US-States/README.md
@@ -1,14 +1,15 @@
-<h1>IAB Privacy&rsquo;s Multi-State Privacy Technical Specifications</h1>
+<h1>GPP US State-Level Technical Specifications</h1>
 
 
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform" target="_blank" rel="noopener">GPP</a> defines a way for local standards to &ldquo;plug-in&rdquo; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md" target="_blank" rel="noopener">GPP client side API </a>. The IAB Privacy&rsquo;s Multi-State Privacy technical specifications were developed by the IAB Tech Lab&rsquo;s Global Privacy Working Group with the IAB&rsquo;s Legal Affairs Council providing the string requirements.&nbsp;</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform" target="_blank" rel="noopener">GPP</a> defines a way for local standards to &ldquo;plug-in&rdquo; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md" target="_blank" rel="noopener">GPP client side API </a>. State-level technical specifications were developed by the IAB Tech Lab’s Global Privacy Working Group with the IAB’s Legal Affairs Council providing the string requirements.</p>
+
 
 <h2>Relevant Specification Documents</h2>
 <ul>
-<li><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-National" target="_blank" rel="noopener">IAB Privacy&rsquo;s US National Privacy Technical Specification</a></li>
-<li><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/CA" target="_blank" rel="noopener">IAB Privacy&rsquo;s California Privacy Technical Specification</a></li>
-<li><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/VA" target="_blank" rel="noopener">IAB Privacy&rsquo;s Virginia Privacy Technical Specification</a></li>
-<li><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/CO" target="_blank" rel="noopener">IAB Privacy&rsquo;s Colorado Privacy Technical Specification</a></li>
-<li><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/UT" target="_blank" rel="noopener">IAB Privacy&rsquo;s Utah Privacy Technical Specification</a></li>
-<li><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/CT" target="_blank" rel="noopener">IAB Privacy&rsquo;s Connecticut Privacy Technical Specification</a></li>
+<li><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-National" target="_blank" rel="noopener">IAB Privacy, Inc.'s US National Privacy Technical Specification</a></li>
+<li><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/CA" target="_blank" rel="noopener">California Privacy Technical Specification</a></li>
+<li><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/VA" target="_blank" rel="noopener">Virginia Privacy Technical Specification</a></li>
+<li><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/CO" target="_blank" rel="noopener">Colorado Privacy Technical Specification</a></li>
+<li><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/UT" target="_blank" rel="noopener">Utah Privacy Technical Specification</a></li>
+<li><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/CT" target="_blank" rel="noopener">Connecticut Privacy Technical Specification</a></li>
 </ul>

--- a/Sections/US-States/UT/GPP Extension: Utah Privacy Technical Specification.md
+++ b/Sections/US-States/UT/GPP Extension: Utah Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-iab-privacy-s-utah-privacy-technical-specification">GPP Extension: IAB Privacy’s Utah Privacy Technical Specification</h1>
+<h1 id="gpp-extension-utah-privacy-technical-specification">GPP Extension: Utah Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the GPP specifications with the IAB Privacy Multi-State Privacy Agreement legal requirements.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Utah section of the GPP specification by those who (i) are Signatories to IAB Privacy, Inc.’s <a href=https://www.iabprivacy.com/>Multi-State Privacy Agreement (MSPA)</a>; and (ii) those who are not signatories of the MSPA.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>

--- a/Sections/US-States/UT/README.md
+++ b/Sections/US-States/UT/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s Utah Privacy Technical Specification
+# Utah Privacy Technical Specification
 
 
 Contained in this directory are technical specifications for Utah privacy strings to support UCPA compliance.

--- a/Sections/US-States/VA/GPP Extension: Virginia Privacy Technical Specification.md
+++ b/Sections/US-States/VA/GPP Extension: Virginia Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-iab-privacy-s-virginia-privacy-technical-specification">GPP Extension: IAB Privacy’s Virginia Privacy Technical Specification</h1>
+<h1 id="gpp-extension-virginia-privacy-technical-specification">GPP Extension: Virginia Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20specification">GPP client side API</a>. This document outlines the technical specification for using the GPP specifications with the IAB Privacy Multi-State Privacy Agreement legal requirements.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Virginia section of the GPP specification by those who (i) are Signatories to IAB Privacy, Inc.’s <a href=https://www.iabprivacy.com/>Multi-State Privacy Agreement (MSPA)</a>; and (ii) those who are not signatories of the MSPA.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>

--- a/Sections/US-States/VA/README.md
+++ b/Sections/US-States/VA/README.md
@@ -1,3 +1,3 @@
-# IAB Privacy’s Virginia Privacy Technical Specification
+# Virginia Privacy Technical Specification
 
 Contained in this directory are technical specifications for Virginia privacy strings to support VCDPA compliance.


### PR DESCRIPTION
This PR includes edits to the 5 existing state sections: CA, CO, CT, VA, UT.

Each State section and readme file has been updated to remove "IAB Privacy" from the title. Additional language was added to the "About this document" portion of each state file, to help clarify proper usage of State sections.

The Sections page was also updated so that all State hyperlinks have the correct revised titles and the page description language was also cleaned up.