### PR TITLE
Cleanup

### DIFF
--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -115,7 +115,7 @@ Requirements for the interface:
 ### What required API commands must a CMP support? <a name="javascript"></a>
 
 
-All CMPs must support all generic commands. Generic commands are commands that can be used independent of [section specifications](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/SectionInformation.md). All generic commands must always be executed immediately without any asynchronous logic and call the supplied callback function immediately. The generic commands are: [‘ping’](#ping), [‘addEventListener’](#addeventlistener), [‘removeEventListener’](#removeeventlistener), [‘hasSection’](#hassection), [‘getSection’](#getsection), and [‘getField’](#getfield). 
+All CMPs must support all generic commands. Generic commands are commands that can be used independent of [section specifications](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/Section%20Information.md). All generic commands must always be executed immediately without any asynchronous logic and call the supplied callback function immediately. The generic commands are: [‘ping’](#ping), [‘addEventListener’](#addeventlistener), [‘removeEventListener’](#removeeventlistener), [‘hasSection’](#hassection), [‘getSection’](#getsection), and [‘getField’](#getfield). 
 
 
 ### What is a CMP ID?

--- a/Core/CMP API Specification.md
+++ b/Core/CMP API Specification.md
@@ -23,15 +23,15 @@
 
 
 ## Introduction
-This is one of the IAB Tech Lab Global Privacy Platform Specifications. It defines the API for Consent Management Platforms (CMPs). The CMP API is the interface a CMP provides to callers (web and in-app) to access information regarding the privacy preferences disclosed and obtained from the end user by the CMP. Both required functionality that the CMP must provide and optional features are described.
+This is one of the IAB Tech Lab's Global Privacy Protocol Specifications. It defines the API for Consent Management Platforms (CMPs). The CMP API is the interface a CMP provides to callers (web and in-app) to access information regarding the privacy preferences disclosed and obtained from the end user by the CMP. Both required functionality that the CMP must provide and optional features are described.
 
 
-### About the Global Privacy Platform
-The Global Privacy Platform (GPP) enables advertisers, publishers and technology vendors in the digital advertising industry to adapt to regulatory demands across markets. It is a single protocol designed to streamline transmitting privacy, consent, and consumer choice signals from sites and apps to ad tech providers. IAB Tech Lab stewards the development of these technical specifications.
+### About the Global Privacy Protocol
+The Global Privacy Protocol (GPP) enables advertisers, publishers and technology vendors in the digital advertising industry to adapt to regulatory demands across markets. It is a single protocol designed to streamline transmitting privacy, consent, and consumer choice signals from sites and apps to ad tech providers. IAB Tech Lab stewards the development of these technical specifications.
 
 
 ### License
-Global Privacy Platform technical specifications governed by the IAB Tech Lab is licensed under a Creative Commons Attribution 3.0 License. To view a copy of this license, visit creativecommons.org/licenses/by/3.0/ or write to Creative Commons, 171 Second Street, Suite 300, San Francisco, CA 94105, USA.
+Global Privacy Protocol technical specifications governed by the IAB Tech Lab is licensed under a Creative Commons Attribution 3.0 License. To view a copy of this license, visit creativecommons.org/licenses/by/3.0/ or write to Creative Commons, 171 Second Street, Suite 300, San Francisco, CA 94105, USA.
 
 
 **Disclaimer**
@@ -54,7 +54,7 @@ Consent Management Platforms (CMPs) provide a user interface to establish transp
 
 Using the API, scripts may obtain the GPP String payload and the information it contains, which is ready to use without having to understand how to “unpack” the payload format. This makes it easy to make immediate data processing decisions based on the returned information.
 
-This API allows for accessing signals across legislations, regulations, and standards. It provides a common interface that can be used to access underlying APIs such as the [IAB TCF](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md) and [USPrivacy](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/USP%20API.md).
+This API allows for accessing signals across legislations, regulations, and standards. It provides a common interface that can be used to access underlying APIs such as the [IAB TCF](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md).
 
 #### API Prefixes
 
@@ -71,7 +71,7 @@ Example API prefixes:
   </tr>
   <tr>
 	  <td>IAB TCF1 (EU)</td>    
-<td><code>tcfeuv1 (no longer used)</code></td>
+<td><code>tcfeuv1</code> (no longer used)</td>
   </tr>
   <tr>
 	  <td>IAB TCF v2 (EU)</td>    
@@ -83,7 +83,11 @@ Example API prefixes:
    </tr>
   <tr>
 	  <td>IAB CCPA/USP v1</td>    
-<td><code>uspv1</code></td>
+<td><code>uspv1</code> (deprecated)</td>
+  </tr>
+  <tr>
+	  <td>California Privacy </td>    
+<td><code>usca</code></td>
   </tr>
 </table>
 
@@ -114,16 +118,16 @@ Requirements for the interface:
 All CMPs must support all generic commands. Generic commands are commands that can be used independent of [section specifications](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/SectionInformation.md). All generic commands must always be executed immediately without any asynchronous logic and call the supplied callback function immediately. The generic commands are: [‘ping’](#ping), [‘addEventListener’](#addeventlistener), [‘removeEventListener’](#removeeventlistener), [‘hasSection’](#hassection), [‘getSection’](#getsection), and [‘getField’](#getfield). 
 
 
-### What is CMP ID?
+### What is a CMP ID?
 
 
 Regional section policy writers may require CMPs to register to operate within the policies for that section. In these cases, CMP IDs must be used if the CMP has an ID. For CMPs that are not registered, a value of 1 must be used by string creators who do not have a CMP ID and are not using a commercially available CMP.
 
 **Examples:**
 
-Publisher A looking to create a GPP string that will contain the section for the US National approach must use 1 as value for CMP ID since the MSPA does not have CMP registration requirements.
+Publisher A looking to create a GPP string that will contain the section for the MSPA US National approach must use 1 as value for CMP ID since the MSPA does not have CMP registration requirements.
 
-Publisher B looking to create a GPP string that will contain sections for the US National approach or the TCF EU must register themselves or work with a registered CMP and use the assigned CMP ID in accordance with the TCF Policies.
+Publisher B looking to create a GPP string that will contain sections for the MSPA US National approach or the TCF EU must register themselves or work with a registered CMP and use the assigned CMP ID in accordance with the TCF Policies.
 
 ________
 #### `ping` <a name="ping"></a>
@@ -176,36 +180,17 @@ cmpDisplayStatus: String, // possible values: hidden, visible, disabled
 
 signalStatus : String, // possible values: not ready, ready
 
-// List of supported APIs (section ids and prefix strings).
-// Example: ["2:tcfeuv2","6:uspv1"] 
-supportedAPIs : Array of string,
+supportedAPIs : Array of string, // List of supported APIs (section ids and prefix strings). Example: ["2:tcfeuv2","6:uspv1"] 
 
-// IAB assigned CMP ID, may be 0 during stub/loading. Refer the above CMP ID section for additional information.
-cmpId : Number,
+cmpId : Number, // IAB assigned CMP ID, may be 0 during stub/loading. Refer the above CMP ID section for additional information.
 
 sectionList : Array of Number, // may be empty during loading of the CMP
 
-// Section ID considered to be in force for this transaction.
-// In most cases, this field should have a single section ID. In rare occasions where such a single section ID
-// can not be determined, the field may contain up to 2 values. During the transition period which ends on
-// September 30, 2023, the legacy USPrivacy section may be determined as applicable along with another US section.
-// In this case, the field may contain up to 3 values where one of the values is 6, representing the
-// legacy USPrivacy section. The value can be 0 or a Section ID specified by the Publisher / Advertiser, during
-// stub / load.
-// When no section is applicable, the value will be [-1].
-applicableSections: Array of Number,
+applicableSections: Array of Number, // Section ID considered to be in force for this transaction. In most cases, this field should have a single section ID. In rare occasions where such a single section ID can not be determined, the field may contain up to 2 values. During the transition period which ends on September 30, 2023, the legacy USPrivacy section may be determined as applicable along with another US section. In this case, the field may contain up to 3 values where one of the values is 6, representing the legacy USPrivacy section. The value can be 0 or a Section ID specified by the Publisher / Advertiser, during stub / load. When no section is applicable, the value will be [-1].
 
-gppString: String // the complete encoded GPP string, may be empty during CMP load
+gppString: String, // the complete encoded GPP string, may be empty during CMP load
 
-// The parsedSections property represents an object of all parsed sections of the gppString property that are supported
-// by the API on this page (see supportedAPIs property). The object contains one property for each supported API with
-// the name of the API as the property name and the value as a parsed representation of this section with exactly the
-// same return as the getSection command, which may include subsections. If a section is supported but not represented
-// in the gppString, it is omitted in the parsedSections object.
-// Please refer to each section's spec for the exact field names and data types in JavaScript. The sections here should
-// be consistent with the GPP string, not placeholder values.
-parsedSections: Object
-
+parsedSections: Object // The parsedSections property represents an object of all parsed sections of the gppString property that are supported by the API on this page (see supportedAPIs property). The object contains one property for each supported API with the name of the API as the property name and the value as a parsed representation of this section with exactly the same return as the getSection command, which may include subsections. If a section is supported but not represented in the gppString, it is omitted in the parsedSections object. Please refer to each section's spec for the exact field names and data types in JavaScript. The sections here should be consistent with the GPP string, not placeholder values.
 }
 
 ```
@@ -407,27 +392,27 @@ A call to the `addEventListener` command must always trigger an immediate call t
   <tr>
     <td><code>listenerRegistered</code></td>
     <td>boolean</td>
-    <td>Only used within the return object to addEventListener command. The data property signals whether the event listener was registered successfully. If data equals true, a listenerId must be sent, otherwise the listenerId must be 0 (zero).</td>
+    <td>Only used within the return object to <code>addEventListener</code> command. The data property signals whether the event listener was registered successfully. If data equals <code>true</code>, a <code>listenerId</code> must be sent, otherwise the <code>listenerId</code> must be <code>0</code> (zero).</td>
   </tr>
   <tr>
     <td><code>listenerRemoved</code></td>
     <td>boolean</td>
-    <td>Only used within the return object to removeEventListener command. The data property signals whether the event listener was successfully removed.</td>
+    <td>Only used within the return object to <code>removeEventListener</code> command. The data property signals whether the event listener was successfully removed.</td>
   </tr>
   <tr>
     <td><code>cmpStatus</code></td>
     <td>string</td>
-    <td>Event is called whenever the status of the CMP changes (e.g. the CMP has finished loading). The data property will contain the new status (e.g. “loaded”)</td>
+    <td>Event is called whenever the status of the CMP changes (e.g. the CMP has finished loading). The data property will contain the new status (e.g. <code>loaded</code>)</td>
   </tr>
   <tr>
     <td><code>cmpDisplayStatus</code></td>
     <td>string</td>
-    <td>Event is called whenever the display status of the CMP changes (e.g. the CMP shows the consent layer). The data property will contain the new display status (e.g. “visible”). Note that this is only applicable when a consent layer is displayed.</td>
+    <td>Event is called whenever the display status of the CMP changes (e.g. the CMP shows the consent layer). The data property will contain the new display status (e.g. <code>visible</code>). Note that this is only applicable when a consent layer is displayed.</td>
     </tr>
     <tr>
     <td><code>signalStatus</code></td>
     <td>string</td>
-    <td>Event is called whenever the signalStatus changes. The data property will contain the new signalStatus value.
+    <td>Event is called whenever the <code>signalStatus</code> changes. The data property will contain the new <code>signalStatus</code> value.
    </td>
     </tr>
   <tr>
@@ -441,15 +426,15 @@ A call to the `addEventListener` command must always trigger an immediate call t
     <td>Event is called whenever the status or content of a section changes (e.g. consent is obtained). The data property will indicate the name (API prefix) of the changed section.</td>
    </tr>
   <tr>
-    <td><code>[API.prefix] or [API-prefix].[Eventname]</code></td>
+    <td><code>[API.prefix]</code> or <code>[API-prefix].[Eventname]</code></td>
     <td>mixed</td>
-    <td>Event is called by the CMP depending on the specific API needs (e.g. IAB TCF EU may specify different events than IAB USP). If the API defines different event types, these can be used by combining API-prefix and eventname, If the API does not specify different event types (e.g. in IAB TCF v2.0), the API-prefix is used as name. The data property will contain mixed data depending on API.</td>
+    <td>Event is called by the CMP depending on the specific API needs (e.g. IAB TCF EU may specify different events than MSPA US National Section). If the API defines different event types, these can be used by combining API-prefix and eventname, If the API does not specify different event types (e.g. in IAB TCF v2.0), the API-prefix is used as name. The data property will contain mixed data depending on API.</td>
      </td>
      </td>
   </tr>
 </table>
 
-The “signalStatus” event shall always be the first (if applicable) and last in a chain of events being fired by the CMP. 
+The `signalStatus` event shall always be the first (if applicable) and last in a chain of events being fired by the CMP. 
 
 A CMP **must** send all relevant events and it **must** send them in a specific order so that listeners (e.g. vendors) can understand when a task is completed. Whenever the CMP starts to change or is about to change any of the existing sections or is processing user input for an existing GPP string, it **must always** first set "signalStatus" to "not ready" and fire the corresponding event. It can then perform the tasks (e.g. change the sections along with firing the section change events). Only when all tasks are completed, the CMP can set the "signalStatus" to "ready" and fire the corresponding event.
 
@@ -471,43 +456,43 @@ The following example illustrates the  events that are fired, and the other orde
 </tr>
 <tr>
 <td>2</td>
-<td>listenerRegistered</td>
+<td><code>listenerRegistered</code></td>
 <td>&nbsp;</td>
 <td>CMP has registered the event listener. Event is immediately fired after registering.</td>
 </tr>
 <tr>
 <td>3</td>
-<td>cmpStatus</td>
-<td>loaded</td>
-<td>CMP is now loaded. Event is fired with name=cmpStatus and data=loaded.</td>
+<td><code>cmpStatus</code></td>
+<td><code>loaded</code></td>
+<td>CMP is now loaded. Event is fired with name = cmpStatus and data = loaded.</td>
 </tr>
 <tr>
 <td>4</td>
-<td>cmpDisplayStatus</td>
-<td>visible</td>
-<td>CMP now displays the consent layer. Event is fired with name=cmpDisplayStatus and data = visible</td>
+<td><code>cmpDisplayStatus</code></td>
+<td><code>visible</code></td>
+<td>CMP now displays the consent layer. Event is fired with name=cmpDisplayStatus and data = visible.</td>
 </tr>
 <tr>
 <td>5</td>
-<td colspan="3"><em>User makes their choices and clicks on accept or reject or save</em></td>
+<td colspan="3"><em>User makes their choices and clicks on accept or reject or save.</em></td>
 </tr>
 <tr>
 <td>6</td>
-<td>cmpDisplayStatus</td>
-<td>hidden</td>
-<td>CMP closed the consent layer and processes user input. Event is fired with name=cmpDisplayStatus and data=hidden</td>
+<td><code>cmpDisplayStatus</code></td>
+<td><code>hidden</code></td>
+<td>CMP closed the consent layer and processes user input. Event is fired with name=cmpDisplayStatus and data = hidden.</td>
 </tr>
 <tr>
 <td>7</td>
-<td>sectionChange</td>
-<td>tcfcav1</td>
-<td>CMP changes the section based on user input. Event is fired with name=sectionChange and data=tcfcav1 Note: if multiple sections are present, multiple sectionChange events may occur after another</td>
+<td><code>sectionChange</code></td>
+<td><code>tcfcav1</code></td>
+<td>CMP changes the section based on user input. Event is fired with name = sectionChange and data = tcfcav1. Note: if multiple sections are present, multiple <code>sectionChange</code> events may occur one after another.</td>
 </tr>
 <tr>
 <td>8</td>
-<td>signalStatus</td>
-<td>ready</td>
-<td>CMP is done with the processing, vendors can use the data. Event is fired with name=signalStatus and data = ready.</td>
+<td><code>signalStatus</code></td>
+<td><code>ready</code></td>
+<td>CMP is done with the processing, vendors can use the data. Event is fired with name = signalStatus and data = ready.</td>
 </tr>
 </tbody>
 </table>
@@ -531,21 +516,21 @@ The following example illustrates the events that are fired, and the order in wh
 </tr>
 <tr>
 <td>2</td>
-<td>listenerRegistered</td>
+<td><code>listenerRegistered</code></td>
 <td>&nbsp;</td>
 <td>CMP has registered the event listener. Event is immediately fired after registering.</td>
 </tr>
 <tr>
 <td>3</td>
-<td>cmpStatus</td>
-<td>loaded</td>
-<td>CMP is now loaded. Event is fired with name=cmpStatus and data=loaded</td>
+<td><code>cmpStatus</code></td>
+<td><code>loaded</code></td>
+<td>CMP is now loaded. Event is fired with name = cmpStatus and data = loaded</td>
 </tr>
 <tr>
 <td>4</td>
-<td>signalStatus</td>
-<td>ready</td>
-<td>CMP is done with the processing (consent information is loaded, no further processing needed, consent layer will not be shown), vendors can use the data. Event is fired with name=signalStatus and data=ready</td>
+<td><code>signalStatus</code></td>
+<td><code>ready</code></td>
+<td>CMP is done with the processing (consent information is loaded, no further processing needed, consent layer will not be shown), vendors can use the data. Event is fired with name = signalStatus and data = ready</td>
 </tr>
 <tr>
 <td>5</td>
@@ -553,15 +538,15 @@ The following example illustrates the events that are fired, and the order in wh
 </tr>
 <tr>
 <td>6</td>
-<td>signalStatus</td>
-<td>Not ready</td>
-<td>CMP is expecting changes, vendors should not use the data but wait and pause their processing. Event is fired with name=signalStatus and data=not ready</td>
+<td><code>signalStatus</code.</td>
+<td><code>Not ready</code></td>
+<td>CMP is expecting changes, vendors should not use the data but wait and pause their processing. Event is fired with name = signalStatus and data = not ready</td>
 </tr>
 <tr>
 <td>7</td>
-<td>cmpDisplayStatus</td>
-<td>visible</td>
-<td>CMP now displays the consent layer. Event is fired with name=cmpDisplayStatus and data=visible</td>
+<td><code>cmpDisplayStatus</code></td>
+<td><code>visible</code></td>
+<td>CMP now displays the consent layer. Event is fired with name = cmpDisplayStatus and data = visible</td>
 </tr>
 <tr>
 <td>8</td>
@@ -571,21 +556,21 @@ The following example illustrates the events that are fired, and the order in wh
 </tr>
 <tr>
 <td>9</td>
-<td>cmpDisplayStatus</td>
-<td>hidden</td>
-<td>CMP closed the consent layer and processes user input. Event is fired with name=cmpDisplayStatus and data=hidden</td>
+<td><code>cmpDisplayStatus</code></td>
+<td><code>hidden</code></td>
+<td>CMP closed the consent layer and processes user input. Event is fired with name = cmpDisplayStatus and data = hidden</td>
 </tr>
 <tr>
 <td>10</td>
-<td>sectionChange</td>
-<td>tcfcav1</td>
-<td>CMP changes the section based on user input. Event is fired with name=sectionChange and data=tcfcav1 Note: If multiple sections are present, multiple sectionChange events may occur after another</td>
+<td><code>sectionChange</code></td>
+<td><code>tcfcav1</code></td>
+<td>CMP changes the section based on user input. Event is fired with name = sectionChange and data = tcfcav1 Note: If multiple sections are present, multiple <code>sectionChange</code> events may occur after another</td>
 </tr>
 <tr>
 <td>11</td>
-<td>signalStatus</td>
-<td>ready</td>
-<td>CMP is done with the processing, vendors can use the data. Event is fired with name=signalStatus and data=ready</td>
+<td><code>signalStatus</code></td>
+<td><code>ready</code></td>
+<td>CMP is done with the processing, vendors can use the data. Event is fired with name = signalStatus and data = ready</td>
 </tr>
 </tbody>
 </table>
@@ -789,16 +774,16 @@ Using the IAB TCF CA v1.0 as an example, the `getVendorList`command would be def
 ```
 getVendorList
 
-Command:     iabtcfcav1.getVendorList
+Command:     tcfcav1.getVendorList
 
 Callback:    function (gvl: GlobalVendorList, success: boolean)
 
 Parameter:   (optional) int or string
 
-Calling with this command and a valid vendorListVersion parameter shall return a GlobalVendorList object to the callback function….
+Calling with this command and a valid vendorListVersion parameter shall return a GlobalVendorList object to the callback function.
 ```
 
-In the example above, a call to` __gpp (‘iabtcfcav1.getVendorList’,myfunction)` will be treated in the same way as a call to `__tcfapi(‘getVendorList’,2,myfunction)` by the CMP.
+In the example above, a call to` __gpp (‘tcfcav1.getVendorList’,myfunction)` will be treated in the same way as a call to `__tcfapi(‘getVendorList’,2,myfunction)` by the CMP.
 
 
 __________

--- a/Core/Consent String Specification.md
+++ b/Core/Consent String Specification.md
@@ -1,4 +1,4 @@
-# Global Privacy Platform String
+# Global Privacy Protocol String
 
 ### Version History
 
@@ -10,14 +10,14 @@
     <td><strong>Comments</strong></td>
   </tr>
   <tr>
-	  <td>Sept 28, 2022</td>    
-<td><code>1.0</code></td>
-    <td>Published final public version</td>
-  </tr>
-	<tr>
 	  <td>Nov 3, 2023</td>    
 <td><code>1.0</code></td>
     <td>Added clarifications to encoding mechanism, fixed encoded header examples</td>
+  </tr>
+  <tr>
+	  <td>Sept 28, 2022</td>    
+<td><code>1.0</code></td>
+    <td>Published final public version</td>
   </tr>
 </table>
 
@@ -25,29 +25,29 @@
 
 ## Introduction
 
-This document is one of the IAB Tech Lab Global Privacy Platform Specifications. It defines the technical implementation of the structure and encoding for a Global Privacy Platform String (GPP String). 
+This document is one of the IAB Tech Lab Global Privacy Protocol Specifications. It defines the technical implementation of the structure and encoding for a Global Privacy Protocol String (GPP String). 
 
 
 ### Additional Reading and Referenced Documents
 
-- [Consent Management Platform JS API](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md)
+- [Consent Management Protocol JS API](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md)
 - [GPP Sections](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections)
 
 
 ### Updates to Standards Needed to Support GPP
 
-Updates were made to existing IAB Tech Lab standards to support the Global Privacy Platform. These updates are based on industry consensus, driven by relevant IAB Tech Lab working groups, including the Global Privacy Working Group and Programmatic Supply Chain Working Group. They include:
+Updates were made to existing IAB Tech Lab standards to support the Global Privacy Protocol. These updates are based on industry consensus, driven by relevant IAB Tech Lab working groups, including the Global Privacy Working Group and Programmatic Supply Chain Working Group. They include:
 
 
 **OpenRTB Attributes:** 
 
 GPP assumes the use of OpenRTB 2.x. 
 
-- Like other existing privacy signals (TCF and USPrivacy), the GPP string is also able to be transported via OpenRTB. This will be included in the Regs object in the November 2022 release. See this [document](https://github.com/InteractiveAdvertisingBureau/openrtb/tree/master/extensions/community_extensions) for approved design prior to release.
+- Like other existing privacy signals (TCF and USPrivacy), the GPP string is also able to be transported via OpenRTB. This is included in the Regs object. See the [OpenRTB 2.x specifications](https://github.com/InteractiveAdvertisingBureau/openrtb/tree/master/extensions/community_extensions) for details.
 
-### About the Global Privacy Platform
+### About the Global Privacy Protocol
 
-The Global Privacy Platform (GPP) enables advertisers, publishers and technology vendors in the digital advertising industry to adapt to regulatory demands across markets. It is a single protocol designed to streamline transmitting privacy, consent, and consumer choice signals from sites and apps to ad tech providers. IAB Tech Lab stewards the development of these technical specifications.
+The Global Privacy Protocol (GPP) enables advertisers, publishers and technology vendors in the digital advertising industry to adapt to regulatory demands across markets. It is a single protocol designed to streamline transmitting privacy, consent, and consumer choice signals from sites and apps to ad tech providers. IAB Tech Lab stewards the development of these technical specifications.
 
 
 ### About IAB Tech Lab
@@ -62,14 +62,14 @@ IAB Tech Lab's Global Privacy Working Group members provide contributions to thi
 
 **License**
 
-Global Privacy Platform technical specifications governed by the IAB Tech Lab is licensed under a Creative Commons Attribution 3.0 License. To view a copy of this license, visit [creativecommons.org/licenses/by/3.0/](creativecommons.org/licenses/by/3.0/) or write to Creative Commons, 171 Second Street, Suite 300, San Francisco, CA 94105, USA.
+Global Privacy Protocol technical specifications governed by the IAB Tech Lab is licensed under a Creative Commons Attribution 3.0 License. To view a copy of this license, visit [creativecommons.org/licenses/by/3.0/](creativecommons.org/licenses/by/3.0/) or write to Creative Commons, 171 Second Street, Suite 300, San Francisco, CA 94105, USA.
 
 **Disclaimer**
 
 THE STANDARDS, THE SPECIFICATIONS, THE MEASUREMENT GUIDELINES, AND ANY OTHER MATERIALS OR SERVICES PROVIDED TO OR USED BY YOU HEREUNDER (THE “PRODUCTS AND SERVICES”) ARE PROVIDED “AS IS” AND “AS AVAILABLE,” AND IAB TECHNOLOGY LABORATORY, INC. (“TECH LAB”) MAKES NO WARRANTY WITH RESPECT TO THE SAME AND HEREBY DISCLAIMS ANY AND ALL EXPRESS, IMPLIED, OR STATUTORY WARRANTIES, INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AVAILABILITY, ERROR-FREE OR UNINTERRUPTED OPERATION, AND ANY WARRANTIES ARISING FROM A COURSE OF DEALING, COURSE OF PERFORMANCE, OR USAGE OF TRADE. TO THE EXTENT THAT TECH LAB MAY NOT AS A MATTER OF APPLICABLE LAW DISCLAIM ANY IMPLIED WARRANTY, THE SCOPE AND DURATION OF SUCH WARRANTY WILL BE THE MINIMUM PERMITTED UNDER SUCH LAW. THE PRODUCTS AND SERVICES DO NOT CONSTITUTE BUSINESS OR LEGAL ADVICE. TECH LAB DOES NOT WARRANT THAT THE PRODUCTS AND SERVICES PROVIDED TO OR USED BY YOU HEREUNDER SHALL CAUSE YOU AND/OR YOUR PRODUCTS OR SERVICES TO BE IN COMPLIANCE WITH ANY APPLICABLE LAWS, REGULATIONS, OR SELF-REGULATORY FRAMEWORKS, AND YOU ARE SOLELY RESPONSIBLE FOR COMPLIANCE WITH THE SAME.
 
 
-## About the Global Privacy Platform String
+## About the Global Privacy Protocol String
 
 In the GPP, a GPP String is used to encapsulate relevant details about transparency and consumer choice and encoded as it applies for each [supported regional or other signal](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections). This document specifies how that string must be formatted and how it must be used.
 
@@ -884,7 +884,7 @@ As part of the first version of GPP, signal integrity will be accomplished in co
 
 ## GPP Identifier <a name="gppstring"></a>
 
-Callers needing to consume privacy signals with business entity level disclosures across multiple markets need the ability to do so with the assurance that business entities do not have duplicate or overlapping IDs. There are already existing vendor lists (see note with non-exhaustive list below) on which the same business entity may appear. Frameworks that are supported by the GPP must retrieve their IDs from the IAB Tech Lab Transparency Center. This will ensure the creation of concurrent non-overlapping vendor IDs. 
+Callers needing to consume privacy signals with business entity level disclosures across multiple markets need the ability to do so with the assurance that business entities do not have duplicate or overlapping IDs. There are already existing vendor lists (see note with non-exhaustive list below) on which the same business entity may appear. Frameworks that are supported by the GPP must retrieve their IDs from the IAB Tech Lab Tools Portal. This will ensure the creation of concurrent non-overlapping vendor IDs. 
 
 
 Registration to participate in a specific framework is governed by the local jurisdiction Policy and T&Cs, who would also be responsible for enforcement and compliance. 
@@ -898,7 +898,7 @@ Vendors should decide which framework signals they plan to participate in to det
 Vendors looking to register for the TCF EU GVL or TCF Canada GVL should do so on this [registration portal](https://register.consensu.org/). Additional details on the Global Vendor List can be found in the [TCF v2 Consent string and vendor list format](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#the-global-vendor-list) specification.
 
 
-Vendors looking to sign the MSPA may do so at the [Transparency Center](https://tools.iabtechlab.com/lspa).  
+Vendors looking to sign the MSPA may do so at the [IAB Tech Lab Tools Portal](https://tools.iabtechlab.com/mspa).  
 
 
 ### I’m a vendor and I already have an GVL ID, is there anything that I need to do?
@@ -918,13 +918,13 @@ Since the pixel is in an `<img>` tag without the ability to execute Javascript, 
 - `${GPP_STRING_XXXXX}` where `XXXXX` is the numeric GPP ID of the vendor receiving the string. - The applicable GPP Section ID must also be inserted, where the ${GPP_SID} macro is present.
 
 
-Vendors not registered to participate in any framework supported by the Global Privacy Platform (e.g. MSPA, TCF CA, TCF EU) may pass ${GPP_STRING} without the GPP ID. Vendors who are registered to participate and have a GPP ID must include it in the macro. When vendors that are callers–who have the option to expand on the macros–are deciding how to proceed with vendor callees not participating in a GPP supported framework (e.g. MSPA, TCF CA, TCF EU), vendors should reference each framework's policy.
+Vendors not registered to participate in any framework supported by the Global Privacy Protocol (e.g. MSPA, TCF CA, TCF EU) may pass ${GPP_STRING} without the GPP ID. Vendors who are registered to participate and have a GPP ID must include it in the macro. When vendors that are callers–who have the option to expand on the macros–are deciding how to proceed with vendor callees not participating in a GPP supported framework (e.g. MSPA, TCF CA, TCF EU), vendors should reference each framework's policy.
 
-**Example when ${GPP_STRING} rather than ${GPP_STRING_XXXXX}may be used:**
+**Example when `${GPP_STRING}` rather than `${GPP_STRING_XXXXX}` may be used:**
 
-The GPP String includes one of the US States sections or the US National section, but the string creator has indicated that the transaction is not covered by the MSPA. Vendors who do not participate in the MSPA may request the string, but may not have a GPP ID. In this case, ${GPP_STRING} may be used.
+The GPP String includes one of the US States sections or the MSPA US National section, but the string creator has indicated that the transaction is not covered by the MSPA. Vendors who do not participate in the MSPA may request the string, but may not have a GPP ID. In this case, `${GPP_STRING}` may be used.
 
-**Example when ${GPP_STRING_XXXXX}is used:**
+**Example when `${GPP_STRING_XXXXX}` is used:**
 
 Vendor A with ID 123 to receive a GPP String which includes the EU TCF v2 as applicable section, an image URL must include two key-value pairs with the URL parameters and macros `gpp=${GPP_STRING_123}` and `gpp_sid=${GPP_SID}`.
 
@@ -960,22 +960,21 @@ The supported URL parameters and the corresponding macros are defined below:
     <td><strong>Representation in URL</strong></td>
   </tr>
   <tr>
-	  <td>gpp</td>    
-<td><code>GPP_STRING_XXXXX (XXXXX is numeric GPP ID - the ID of the vendor on the GPP ID List who is expecting this URL call)</code></td>
-    <td>&gpp=${GPP_STRING_123}</td>
+	  <td><code>gpp</code></td>    
+<td><code>GPP_STRING_XXXXX</code> (<code>XXXXX</code> is the numeric GPP ID - the ID of the vendor on the GPP ID List who is expecting this URL call)</td>
+    <td><code>&gpp=${GPP_STRING_123}</code></td>
     </tr>
   <tr>
-	  <td>gpp_sid</td>    
+	  <td><code>gpp_sid</code></td>    
 <td><code>GPP_SID</code></td>
-    <td>&gpp_sid=${GPP_SID}</td>
+    <td><code>&gpp_sid=${GPP_SID}</code></td>
    </td>
    </td>
   </tr>
 </table>
 
 
-
-The service making the call must replace the macros with appropriate values described in the table below. For macro ${GPP_STRING_XXXXX}, the service making the call must also check that the macro name contains a valid GPP ID before replacing the macro. 
+The service making the call must replace the macros with appropriate values described in the table below. For macro `${GPP_STRING_XXXXX}`, the service making the call must also check that the macro name contains a valid GPP ID before replacing the macro. 
 
 
 The creator of the URL should ensure these parameters are added only once, and are passed to services which are expecting them and can handle them properly.
@@ -987,14 +986,14 @@ The creator of the URL should ensure these parameters are added only once, and a
     <td><strong>Purpose</strong></td>
   </tr>
   <tr>
-	  <td>${GPP_STRING_XXXXX}</td>    
-<td><code>Url-safe base64-encoded GPP string.</code></td>
+	  <td><code>${GPP_STRING_XXXXX}</code></td>    
+<td>Url-safe base64-encoded GPP string.</td>
     <td>Encodes the GPP string, as obtained from the CMP JS API or OpenRTB</td>
     </tr>
   <tr>
-	  <td>${GPP_SID}</td>    
-<td><code>The section ID(s) in force for the current transaction. In most cases, this field should have a single section ID. In rare occasions where such a single section ID can not be determined, the field may contain up to 2 values, separated by a comma.</code></td>
-    <td>As the GPP String may encode user preferences for multiple jurisdictions, this field indicates to the callee which section of the string is considered “in force” by the caller. This should match the value returned by the CMP API (see below).</td>
+	  <td><code>${GPP_SID}</code></td>    
+<td>The section ID(s) in force for the current transaction. In most cases, this field should have a single section ID. In rare occasions where such a single section ID can not be determined, the field may contain up to 2 values, separated by a comma.</td>
+    <td>As the GPP String may encode user preferences for multiple jurisdictions, this field indicates to the callee which section of the string is considered “in force” by the caller. This should match the value returned by the CMP API.</td>
    </td>
    </td>
   </tr>

--- a/Core/Consent String Specification.md
+++ b/Core/Consent String Specification.md
@@ -43,7 +43,7 @@ Updates were made to existing IAB Tech Lab standards to support the Global Priva
 
 GPP assumes the use of OpenRTB 2.x. 
 
-- Like other existing privacy signals (TCF and USPrivacy), the GPP string is also able to be transported via OpenRTB. This is included in the Regs object. See the [OpenRTB 2.x specifications](https://github.com/InteractiveAdvertisingBureau/openrtb/tree/master/extensions/community_extensions) for details.
+- Like other existing privacy signals (TCF and USPrivacy), the GPP string is also able to be transported via OpenRTB. This is included in the Regs object. See the [OpenRTB 2.x specifications](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#objectregs) for details.
 
 ### About the Global Privacy Protocol
 
@@ -190,7 +190,7 @@ The following details provide information on creating, storing, and managing a G
 <li>For sections that use a different encoding mechanism, ensure that the data is websafe and does not include the “~” (tilde) character or the "." (dot) character.</li>
 </ul>
 </li>
-<li><b>Create header section.</b> See examples of the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/consent-string-clarifications/Core/Consent%20String%20Specification.md?pr=%2FInteractiveAdvertisingBureau%2FGlobal-Privacy-Platform%2Fpull%2F83#header-examples">header section</a> below.
+<li><b>Create header section.</b> See examples of the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#header-examples">header section</a> below.
 	<ol type=1>
 		<li>Create a bit representation of the GPP header section including all Section IDs for discrete sections in a sorted order.</li>
 		<li>Add padding (0) on the right to get to a total bit length that is a multiple of 6 bits.</li>
@@ -879,7 +879,7 @@ Using the same cases as in the [Header Examples](#header) above, the following e
 
 ## Signal Integrity
 
-As part of the first version of GPP, signal integrity will be accomplished in concert with the [Accountability Platform.](https://iabtechlab.com/wp-content/uploads/2021/03/iabtechlab_accountability_platform_rfc_2021_march.pdf) The Global Privacy Working Group is committed to introducing signal integrity technology for GPP in future versions. 
+As part of the first version of GPP, signal integrity will be accomplished in concert with the [Accountability Platform.](https://github.com/InteractiveAdvertisingBureau/Accountability-Platform) The Global Privacy Working Group is committed to introducing signal integrity technology for GPP in future versions. 
 
 
 ## GPP Identifier <a name="gppstring"></a>

--- a/Core/README.md
+++ b/Core/README.md
@@ -1,16 +1,16 @@
-# Global Privacy Platform
+# Global Privacy Protocol
 
 
-Hosted in this repository are the technical specifications for the IAB Global Privacy Platform (GPP). The relevant specifications: 
+Hosted in this repository are the technical specifications for the IAB Global Privacy Protocol (GPP). The relevant specifications: 
 
-- Global Privacy Platform String
+- Global Privacy Protocol String
 - Consent Management API
 - Data Activities and Manifests
 - Supported Sections
 
-### About the Global Privacy Platform
+### About the Global Privacy Protocol
 
-The Global Privacy Platform (GPP) has the objective to enable all parties in the digital advertising chain to comply with regional privacy regulations more easily. It is a transport layer that communicates user consent and preference signaling throughout the digital supply chain that supports existing consent formats and is flexible enough to support new markets with unique needs. IAB Tech Lab stewards the development of these technical specifications.
+The Global Privacy Protocol (GPP) has the objective to enable all parties in the digital advertising chain to comply with regional privacy regulations more easily. It is a transport layer that communicates user consent and preference signaling throughout the digital supply chain that supports existing consent formats and is flexible enough to support new markets with unique needs. IAB Tech Lab stewards the development of these technical specifications.
 
 ### Value for Users
 
@@ -40,7 +40,7 @@ Learn more at [iabtechlab.com](iabtechlab.com).
 IAB Tech Lab's Global Privacy Working Group members provide contributions to this repository. Participants in the Global Privacy Working group must be members of IAB Tech Lab. Technical Governance for the project is provided by the IAB Tech Lab Privacy & Rearc Commit Group.
 License
 
-Global Privacy Platform technical specifications governed by the IAB Tech Lab is licensed under a Creative Commons Attribution 3.0 License. To view a copy of this license, visit [creativecommons.org/licenses/by/3.0/](creativecommons.org/licenses/by/3.0/) or write to Creative Commons, 171 Second Street, Suite 300, San Francisco, CA 94105, USA.
+Global Privacy Protocol technical specifications governed by the IAB Tech Lab is licensed under a Creative Commons Attribution 3.0 License. To view a copy of this license, visit [creativecommons.org/licenses/by/3.0/](creativecommons.org/licenses/by/3.0/) or write to Creative Commons, 171 Second Street, Suite 300, San Francisco, CA 94105, USA.
 
 **Disclaimer**
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Global-Privacy-Platform
+ # Global Privacy Protocol
 
-Hosted in this repository are the technical specifications for the IAB Global Privacy Platform (GPP). The relevant documents are:
+Hosted in this repository are the technical specifications for the Global Privacy Protocol (GPP). The relevant documents are:
 
-- [Global Privacy Platform Consent String Specification](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md)
+- [Global Privacy Protocol Consent String Specification](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md)
 - [Consent Management API Specification](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md)
 - [Supported Sections](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/Section%20Information.md)
 
-### About the Global Privacy Platform
+### About the Global Privacy Protocol
 
-The Global Privacy Platform (GPP) has the objective to enable all parties in the digital advertising chain to comply with regional privacy regulations more easily. It is a transport layer that communicates user consent and preference signaling throughout the digital supply chain that supports existing consent formats and is flexible enough to support new markets with unique needs. IAB Tech Lab stewards the development of these technical specifications.
+The Global Privacy Protocol (GPP) has the objective to enable all parties in the digital advertising chain to comply with regional privacy regulations more easily. It is a transport layer that communicates user consent and preference signaling throughout the digital supply chain that supports existing consent formats and is flexible enough to support new markets with unique needs. IAB Tech Lab stewards the development of these technical specifications.
 
 ### About IAB Tech Lab <a name="about-iabtechlab"></a>
 
@@ -23,9 +23,9 @@ IAB Tech Lab's Global Privacy Working Group members provide contributions to thi
 
 ### License <a name="license"></a>
 
-Global Privacy Platform technical specifications governed by the IAB Tech Lab is licensed under a Creative Commons Attribution 3.0 License.   To view a copy of this license, visit [creativecommons.org/licenses/by/3.0/](http://creativecommons.org/licenses/by/3.0/) or write to Creative Commons, 171 Second Street, Suite 300, San Francisco, CA 94105, USA. 
+Global Privacy Protocol technical specifications governed by the IAB Tech Lab is licensed under a Creative Commons Attribution 3.0 License.   To view a copy of this license, visit [creativecommons.org/licenses/by/3.0/](http://creativecommons.org/licenses/by/3.0/) or write to Creative Commons, 171 Second Street, Suite 300, San Francisco, CA 94105, USA. 
 
-By submitting an idea, specification, software code, document, file, or other material (each, a “Submission”) to the Global Privacy Platform repository, to any member of the Global Privacy Working Group, or to the IAB Tech Lab in relation to Global Privacy Platform you agree to and hereby license such Submission to the IAB Tech Lab under the Creative Commons Attribution 3.0 License and agree that such Submission may be used and made available to the public under the terms of such license.  If you are a member of the IAB Tech Lab then the terms and conditions of the [IPR Policy](https://iabtechlab.com/ipr-iab-techlab/acknowledge-ipr/) may also be applicable to your Submission, and if the IPR Policy is applicable to your Submission then the IPR Policy will control in the event of a conflict between the Creative Commons Attribution 3.0 License and the IPR Policy.
+By submitting an idea, specification, software code, document, file, or other material (each, a “Submission”) to the Global Privacy Protocol repository, to any member of the Global Privacy Working Group, or to the IAB Tech Lab in relation to Global Privacy Protocol you agree to and hereby license such Submission to the IAB Tech Lab under the Creative Commons Attribution 3.0 License and agree that such Submission may be used and made available to the public under the terms of such license.  If you are a member of the IAB Tech Lab then the terms and conditions of the [IPR Policy](https://iabtechlab.com/ipr-iab-techlab/acknowledge-ipr/) may also be applicable to your Submission, and if the IPR Policy is applicable to your Submission then the IPR Policy will control in the event of a conflict between the Creative Commons Attribution 3.0 License and the IPR Policy.
 
 ![](https://drive.google.com/uc?id=1cbwEGlb8S69SndIDoHnvc5_3TfmkGM7R)
 


### PR DESCRIPTION
Miscellaneous cleanup with no normative changes to the readme and Core specifications. This includes: 
- Reordered Version details in applicable files so that the latest is on top
- Renamed references from 'Global Privacy Platform' to 'Global Privacy Protocol' 
- Updated and fixed formatting throughout 
- Fixed broken links 
- Corrected example in CMP API Specification that used incorrect prefix
- Removed some references to USPrivacy since that's deprecated replaced with other examples