### PR TITLE
August 2026 public comment

### DIFF
--- a/Sections/Section Information.md
+++ b/Sections/Section Information.md
@@ -5,14 +5,13 @@
     <td><strong>Date</strong></td>
     <td><strong>Comments</strong></td>
   </tr>
-  <tr>
-	  <td>Sept 28, 2022</td>    
-    <td>Published final public version</td>
-  </tr>
 	  <tr>
 	  <td>June, 2023</td>    
     <td>Fixed Canada api name</td>
-  </tr>
+  </tr></tr>
+  <tr>
+	  <td>Sept 28, 2022</td>    
+    <td>Published final public version</td>
   </table>
   
 ### Section IDs
@@ -53,7 +52,7 @@ Each section represents a unique privacy signal, usually a unique jurisdiction. 
   <tr>
     <td><code>6</code></td>
     <td>uspv1</td>
-    <td><a href="https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/US%20Privacy%20String.md">USPrivacy String </a>(Unencoded Format)</td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/US%20Privacy%20String.md">USPrivacy String </a>(deprecated)</td>
   </tr>
   <tr>
     <td><code>7</code></td>
@@ -63,132 +62,123 @@ Each section represents a unique privacy signal, usually a unique jurisdiction. 
   <tr>
     <td><code>8</code></td>
     <td>usca</td>
-    <td>US - California section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/CA">US - California section </a></td>
      </tr>
   <tr>
     <td><code>9</code></td>
     <td>usva</td>
-    <td>US - Virginia section </td>
+    <td><a href= "https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/VA">US - Virginia section </a></td>
       </tr>
   <tr>
     <td><code>10</code></td>
     <td>usco</td>
-    <td>US - Colorado section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/CO">US - Colorado section </a></td>
   </tr>
   <tr>
     <td><code>11</code></td>
     <td>usut</td>
-    <td>US - Utah section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/UT">US - Utah section </a></td>
   </tr>
   <tr>
     <td><code>12</code></td>
     <td>usct</td>
-    <td>US - Connecticut section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/CT">US - Connecticut section </a></td>
      </td>
      </td>
   </tr>
 <tr>
     <td><code>13</code></td>
     <td>usfl</td>
-    <td>US - Florida section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/FL">US - Florida section </a></td>
      </td>
      </td>
 <tr>
     <td><code>14</code></td>
     <td>usmt</td>
-    <td>US - Montana section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/MT">US - Montana section </a></td>
      </td>
      </td>
   </tr>
  <tr>
     <td><code>15</code></td>
     <td>usor</td>
-    <td>US - Oregon section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/OR">US - Oregon section </a></td>
      </td>
      </td>
   </tr>
  <tr>
     <td><code>16</code></td>
     <td>ustx</td>
-    <td>US - Texas section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/TX">US - Texas section </a></td>
      </td>
      </td>
   </tr>
 <tr>
     <td><code>17</code></td>
     <td>usde</td>
-    <td>US - Delaware section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/DE">US - Delaware section </a></td>
      </td>
      </td>
   </tr>
  <tr>
     <td><code>18</code></td>
     <td>usia</td>
-    <td>US - Iowa section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/IA">US - Iowa section </a></td>
      </td>
      </td>
   </tr>
  <tr>
     <td><code>19</code></td>
     <td>usne</td>
-    <td>US - Nebraska section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/NE">US - Nebraska section </a></td>
      </td>
      </td>
   </tr>
  <tr>
     <td><code>20</code></td>
     <td>usnh</td>
-    <td>US - New Hampshire section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/NH">US - New Hampshire section </a></td>
      </td>
      </td>
   </tr>
  <tr>
     <td><code>21</code></td>
     <td>usnj</td>
-    <td>US - New Jersey section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/NJ">US - New Jersey section </a></td>
      </td>
      </td>
   </tr>
  <tr>
     <td><code>22</code></td>
     <td>ustn</td>
-    <td>US - Tennessee section </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/TN">US - Tennessee section </a></td>
      </td>
      </td>
   </tr>
   <tr>
-    <td><code>23</code></mn>
+    <td><code>23</code></td>
     <td>usmn</td>
-    <td>US - Minnesota section </mn>
-     </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/MN">US - Minnesota section </a></td>
   </tr>
   <tr>
-    <td><code>24</code></mn>
+    <td><code>24</code></td>
     <td>usmd</td>
-    <td>US - Maryland section </mn>
-     </td>
-     </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/MD">US - Maryland section </a></td>
   </tr>
   <tr>
-    <td><code>25</code></mn>
+    <td><code>25</code></td>
     <td>usin</td>
-    <td>US - Indiana section </mn>
-     </td>
-     </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/IN">US - Indiana section </a></td>
   </tr>
   <tr>
-    <td><code>26</code></mn>
+    <td><code>26</code></td>
     <td>usky</td>
-    <td>US - Kentucky section </mn>
-     </td>
-     </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/KY">US - Kentucky section </a></td>
   </tr>
   <tr>
-    <td><code>27</code></mn>
+    <td><code>27</code></td>
     <td>usri</td>
-    <td>US - Rhode Island section </mn>
-     </td>
-     </td>
+    <td><a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/tree/main/Sections/US-States/RI">US - Rhode Island section </a></td>
   </tr>
 </table>
 

--- a/Sections/US-National/IAB Privacy’s Multi-State Privacy Agreement (MSPA) US National Technical Specification.md
+++ b/Sections/US-National/IAB Privacy’s Multi-State Privacy Agreement (MSPA) US National Technical Specification.md
@@ -5,7 +5,7 @@
 
 <p>The <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a>  standard is designed to be extensible so that support for new regulations can be added without the need to update existing capabilities defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical requirements for using the GPP specification with the IAB Privacy Multi-State Privacy Agreement (MSPA) legal requirements.</p>
 
-<h3>Version History&nbsp;</h3>
+<h3>Version History</h3>
 <div>
 <table>
 <tbody>
@@ -15,23 +15,29 @@
 <td><strong>Comments</strong></td>
 </tr>
 <tr>
-<td>December 2022</td>
-<td>1.0</td>
-<td>Version 1.0 released</td>
+<td>August 2026 <i>(Public Comment)</i></td>
+<td>3.0</td>
+<td>Updated to support the Fifth Amended and Restated MSPA</td>
 </tr>
 <tr>
 <td>October 2024</td>
 <td>2.0</td>
 <td>Version 2.0 – Added support for DE, IN, IA, KY, MD, MI, MT, NH, NE, NJ, OR, RI, TN, TX in accordance with the Second Amended and Restated MSPA.</td>
 </tr>
+<tr>
+<td>December 2022</td>
+<td>1.0</td>
+<td>Version 1.0 released</td>
+</tr>
 </tbody>
 </table>
 </div>
 
 <h2>Multi-State Privacy Agreement (MSPA) US National Section</h2>
-<p>The MSPA US National Section string includes the components described below.&nbsp;</p>
+<p>The MSPA US National Section string includes the components described below.</p>
+
 <p>
-Implementers should employ the MSPA US National Privacy Section to adhere to the “National Approach” for their Processing of a Consumer’s Personal Information, as defined in Section 1.81 of the MSPA.&nbsp; The MSPA US National Privacy Section should be used by MSPA Signatories and Certified Partners in connection with a Covered Transaction pursuant to the MSPA.&nbsp; Click <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/"><span style="color: rgb(17, 85, 204)">here</span></a> to access the text of the MSPA and to review the Signatory and Certified Partner Identification List.</p>
+Implementers must support the MSPA US National Privacy Section to adhere to the “US National Approach” for their Processing of a Consumer’s Personal Information, as defined in Section 1.80 of the MSPA. The MSPA US National Section must only be used by MSPA Signatories and Certified Partners in connection with a Covered Transaction pursuant to the MSPA. Click <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/">here</a> to access IABPrivacy.com which includes links to the text of the MSPA and the Signatory and Certified Partner Identification List.</p>
 
 <h3>Summary</h3>
 <div>
@@ -45,10 +51,10 @@ Implementers should employ the MSPA US National Privacy Section to adhere to the
 <tr>
 <td>GPP SectionID</td>
 <td>7</td>
-<td>The MSPA US National Section is assigned GPP Section ID 7.&nbsp;</td>
+<td>The MSPA US National Section is assigned <a target="_blank" rel="noopener noreferrer nofollow" href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/Section%20Information.md">GPP Section ID</a> 7.</td>
 </tr>
 <tr>
-<td>Client side API prefix</td>
+<td>Client-side API prefix</td>
 <td>usnat</td>
 <td>The MSPA US National Section is assigned the client side API prefix “usnat” in the GPP Client Side API.</td>
 </tr>
@@ -57,17 +63,69 @@ Implementers should employ the MSPA US National Privacy Section to adhere to the
 </div>
 
 <h3>Section encoding</h3>
-<p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
+<p>Note that JS is case sensitive, so field name references should be UpperCamelCase with exactly the same spelling as the strings in the "Field Name" column. <a target="_blank" rel="noopener noreferrer nofollow" href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding">This table</a> explains how to map the GPP field types to JavaScript native data types. Please refer to the <a target="_blank" rel="noopener noreferrer nofollow" href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-">PingReturn's parsedSections object</a> for an example of how to reference fields.<p>
 
-<h4>Core Segment</h4>
-<p>The core segment must always be present. Where terms are capitalized in the &lsquo;description&rsquo; field they are defined terms in applicable State Privacy Laws and the MSPA. It consists of the following fields:</p>
+<h4>Section Header</h4>
+<p>The section header is required and must always be present, it includes the following fields</p>
+<div>
+<table>
+<tbody>
+<tr>
+<td><strong>Field Name</strong></td>
+<td><strong>Type</strong></td>
+<td><strong>Description</strong></td>
+</tr>
+<tr>
+<td><code>SectionId</code></td>
+<td>Int(6)</td>
+<td>Section ID from the <a target="_blank" rel="noopener noreferrer nofollow" href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/Section%20Information.md">Section IDs list.</a></td>
+</tr>
+<tr>
+<td><code>Version</code></td>
+<td>Int(6)</td>
+<td>The version of this section specification used to encode the string.</td>
+</tr>
+</tr>
+<tr>
+<td><code>SubSections</code></td>
+<td>Range (Fibonacci)</td>
+<td>List of subsection ids that are contained in this section. The IDs must be represented in the order the related subsections appear in the string. The Core subsection is required and always included first, so its ID (zero) is not included in the subsection IDs list.</td>
+</tr>
+</tbody>
+</table>
+</div>
+
+<h4>Subsection IDs</h4>
+<p>The currently defined MSPA US National subsections are:</p>
+<div>
+<table>
+<tbody>
+<tr>
+<td><strong>Subsection ID</strong></td>
+<td><strong>Description</strong></td>
+</tr>
+<tr>
+<td><code>0</code></td>
+<td>Core</td>
+</tr>
+<tr>
+<td><code>1</code></td>
+<td>GPC</td>
+</tr>
+</tbody>
+</table>
+</div>
+
+
+<h4>Core Subsection</h4>
+<p>The Core subsection must always be present. Where terms are capitalized in the "Description" column they refer to defined terms in Applicable State Privacy Laws and the MSPA. The Core subsection consists of the following fields:</p>
 
 <div>
 <table>
 <thead>
 <tr>
 <th>
-<p><strong>Field name</strong></p>
+<p><strong>Field Name</strong></p>
 </th>
 <th>
 <p><strong>GPP Field Type</strong></p>
@@ -79,482 +137,39 @@ Implementers should employ the MSPA US National Privacy Section to adhere to the
 </thead>
 <tbody>
 <tr>
-<td>Version</td>
+<td><code>MspaVersion</code></td>
 <td>Int(6)</td>
-<td>The version of this section specification used to encode the string.</td>
+<td>Version of the MSPA</td>
 </tr>
 <tr>
-<td>SharingNotice</td>
+<td><code>MspaNotice</code></td>
 <td>Int(2)</td>
-<td>Notice Describing Your Processing of Personal Information pursuant to the National Approach as defined in Section 1.81(a) of the MSPA, which incorporates the statutory provisions and regulations set forth below:<p><p>
-<ul>
-<li>Virginia Code 59.1-578(C)(4) &ndash; (5)</li>
-<li>Colo. Rev. Stat. 6-1-1308(1)(1)(IV) &ndash; (V)</li>
-<li>Utah Code 13-61-302(1)(1)(iv) &ndash; (v)</li>
-<li>Conn. PA No. 22-15, Sec. 6(3)(4)-(5)</li>
-<li>Cal. Civ. Code 1798.100(a), Cal. Civ. Code 1798.130(a)(5), and 11 CCR 7011 - 7013</li>
-<li>Colo. Rev. Stat. 6-1-1308(1)(a) and 4 CCR 904-3-3 and 6.03.</li>
-<li>Conn. Gen. Stat. § 42-520(c)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(c)</li>
-<li>Ind. Code Ann. §§ 24-15-4-3</li>
-<li>Iowa Code § 715D.4(5)</li>
-<li>Kentucky Act, Sec. 4(3)</li>
-<li>Maryland Act 14-4607(D)</li>
-<li>Minn. Stat. § 325O.07, Subd. 1(a)</li>
-<li>Montana Act, Sec. 7(5)</li>
-<li>N.H. Rev. Stat. 507-H:6(III)</li>
-<li>Nebraska Act, Sec. 13</li>
-<li>New Jersey Act, Sec. 3(a)</li>
-<li>Oregon Act, Sec. 5(4)</li>
-<li>Rhode Island Act 6-48.1-3(a)</li>
-<li>Tenn. Code Ann. 47-18-3305(c)</li>
-<li>Tex. Bus. & Com. Code §§ 541.102(a)</li>
-<li>Utah Code 13-61-302(1)(a)</li>
-<li>Virginia Code 59.1-578(C)</li>
-</ul>
-<code>0</code>  Not Applicable. The Business does not share Process Personal Informatin.<p><code>1</code>  Yes, notice was provided<p><code>2</code>  No, notice was not provided</td>
-</tr>
-<tr>
-<td>SaleOptOutNotice</td>
-<td>Int(2)</td>
-<td>Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Information pursuant to the National Approach as defined in Section 1.81(b) of the MSPA, which incorporates the statutory provisions and regulations set forth below:<p><p>
-<ul>
-<li>Cal. Civ. Code 1798.100(a)(1), (3), Cal. Civ. Code 1798.135(a), Cal. Civ. Code 1798.135(b), and 11 CCR 7013.</li>
-<li>Colo. Rev. Stat 6-1-1308(1)(b), Colo. Rev. Stat. 6-1-1306(1)(a)(III), and 4 CCR 904-3-4.03.</li>
-<li>Conn. Gen. Stat. § 42-520(d) and Conn. Gen. Stat. § 42-518(b)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(d)</li>
-<li>Ind. Code Ann. § 24-15-4-4</li>
-<li>Iowa Code § 715D.4(6)</li>
-<li>Kentucky Act, Sec. 4(4)</li>
-<li>Maryland Act 14-4607(E)</li>
-<li>Minn. Stat. § 325O.07, Subd. 1(b)</li>
-<li>Montana Act, Sec. 7(4)</li>
-<li>N.H. Rev. Stat. 507-H:6(IV)</li>
-<li>Nebraska Act, Sec. 14</li>
-<li>New Jersey Act, Sec. 3(b)</li>
-<li>Oregon Act, Sec. 5(4)(c)</li>
-<li>Rhode Island Act 6-48.1-3(b)</li>
-<li>Tenn. Code Ann. 47-18-3305(d)</li>
-<li>Tex. Bus. & Com. Code § 541.103</li>
-<li>Utah Code 13-61-302(1)(b)(i)</li>
-<li>Virginia Code 59.1-578(D)</li>
-</ul>
-<code>0</code>  Not Applicable. The Business does not Sell Personal Information.<p><code>1</code>  Yes, notice was provided<p><code>2</code>  No, notice was not provided</td>
-</tr>
-<tr>
-<td>SharingOptOutNotice</td>
-<td>Int(2)</td>
-<td>Notice of the Opportunity to Opt Out of the Sharing of the Consumer’s Personal Information pursuant to the National Approach as defined in Section 1.81(b) of the MSPA, which incorporates the statutory provisions and regulations set forth below:<p><p>&nbsp;(i) Cal. Civ. Code 1798.100(a)(1), (3), Cal. Civ. Code 1798.135(a), Cal. Civ. Code 1798.135(b), and 11 CCR 7013<p><code>0</code>  Not Applicable. The Business does not Share Personal Information.<p><code>1</code>  Yes, notice was provided<p><code>2</code>  No, notice was not provided</td>
-</tr>
-<tr>
-<td>TargetedAdvertisingOptOutNotice</td>
-<td>Int(2)</td>
-<td>Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Information for Targeted Advertising pursuant to the National Approach as defined in Section 1.81(b) of the MSPA, which incorporates the statutory provisions and regulations set forth below:<p><p>
-<ul>
-<li>Colo. Rev. Stat 6-1-1308(1)(b), Colo. Rev. Stat. 6-1-1306(1)(a)(III), and 4 CCR 904-3-4.03.</li>
-<li>Conn. Gen. Stat. § 42-520(d) and Conn. Gen. Stat. § 42-518(b)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(d)</li>
-<li>Ind. Code Ann. § 24-15-4-4</li>
-<li>Iowa Code § 715D.4(6)</li>
-<li>Kentucky Act, Sec. 4(4)</li>
-<li>Maryland Act 14–4605(B)(7)(I)</li>
-<li>Minn. Stat. § 325O.07, Subd. 1(b)</li>
-<li>Montana Act, Sec. 7(4)</li>
-<li>N.H. Rev. Stat. 507-H:6(IV)</li>
-<li>Nebraska Act, Sec. 14</li>
-<li>New Jersey Act, Sec. 3(b)</li>
-<li>Oregon Act, Sec. 5(4)(h)</li>
-<li>Rhode Island Act 6-48.1-3(b)</li>
-<li>Tenn. Code Ann. 47-18-3305(d)</li>
-<li>Tex. Bus. & Com. Code § 541.103</li>
-<li>Utah Code 13-61-302(1)(b)(ii)</li>
-<li>Virginia Code 59.1-578(D)</li>
-</ul>
-<code>0</code>  Not Applicable. The Business does not Process Personal Information for Targeted Advertising.<p><code>1</code>  Yes, notice was provided<p><code>2</code>  No, notice was not provided</td>
-</tr>
-<tr>
-<td>SensitiveDataProcessingOptOutNotice</td>
-<td>Int(2)</td>
-<td>Notice to the Consumer of the Consumer’s right to opt out of the Processing of the Consumer’s Sensitive Personal Information that adheres to the requirements of an optional addendum to the MSPA that IAB may, in the future, promulgate to govern the Processing of Sensitive Personal Information by Signatories and Certified Partners for Digital Advertising Activities pursuant to Section 1.28 of the MSPA, which will incorporate the statutory provisions and regulations set forth below:<p><p>
-<ul>
-    <li>Utah Code 13-61-302(3)(a)</li>
-    <li>Iowa Code §&nbsp; 715D.4(2)</li>
-</ul>
-<p>Note: A Business adhering to the National Approach must obtain consent from Consumers before processing their sensitive data or sensitive personal information. However, Utah Code 13-61-302(3)(a) and Iowa Code §&nbsp; 715D.4(2) requires a controller to provide a consumer with clear notice of the right to opt out of the controller’s processing of the consumer’s sensitive data prior to any such processing. To adhere to these requirements, Businesses following the National Approach should consider incorporating clear notice of the right to opt out as part the process they use to prompt the user to provide consent, for example, by informing Consumers that if they provide consent, they retain the right to opt out (i.e., withdraw consent) of the Business’s processing of their sensitive data at any time. </p>
-<code>0</code>  Not Applicable. The Business does not Process Sensitive Data.<p><code>1</code>  Yes, notice was provided<p><code>2</code>  No, notice was not provided</td>
-</tr>
-<tr>
-<td>SensitiveDataLimitUseNotice</td>
-<td>Int(2)</td>
-<td>Link to the Consumer that enables the Consumer, or a person authorized by the Consumer, to limit the Business’s use or disclosure of the Consumer’s Sensitive Personal Information and that adheres to the requirements of an optional addendum to the MSPA that IAB may, in the future, promulgate to govern the Processing of Sensitive Personal Information by Signatories and Certified Partners for Digital Advertising Activities as provided in Section 1.28 of the MSPA, which will incorporate the statutory provisions and regulations set forth below:<p><p>
-<ul>
-    <li>
-        <p><span >Cal. Civ. Code 1798.100(a)(2)-(3), Cal. Civ. Code 1798.135(a); Cal. Civ. Code 1798.135(b), and 11 CCR 7014</span>
-        </p>
-    </li>
-</ul>
-<code>0</code>  Not Applicable. The Business does not use or disclose Sensitive Data.<p><code>1</code>  Yes, notice was provided<p><code>2</code>  No, notice was not provided</td>
-</tr>
-<tr>
-<td>SaleOptOut</td>
-<td>Int(2)</td>
-<td>Consumer submitted a request to opt out of the Sale of Personal Information, pursuant to the National Approach as defined in Section 1.81(c) of the MSPA, which incorporates Cal. Civ. Code 1798.120(a) and 11 CCR 7026, Virginia Code 59.1-577(A)(5)(i), Colo. Rev. Stat. 6-1-1306(1)(a)(I)(B), Utah Code 13-61-201(4)(b), Conn. Gen. Stat. § 42-518(a), Iowa Code § 715D.3(1)(d), Ind. Code Ann. § 24-15-3-1(b)(5), Tenn. Code Ann. 47-18-3304(a)(2)(E)(i), Tex. Bus. &amp; Com. Code § 541.051(b)(5)(B), Montana Act, Sec. 5(1)(e)(ii), Oregon Act, Sec. 3(1)(d)(B), Del. Code Ann. tit. 6, § 12D-104(a)(6)(b), New Jersey Act, Sec. 7(a)(5), N.H. Rev. Stat. 507-H:4(I)(e), Nebraska Act, Sec. 7(e)(ii), Kentucky Act, Sec. 3(2)(e), Minn. Stat. § 325O.05, Subd. 1(f), Maryland Act 14–4605(B)(7)(II), or Rhode Island Act 6-48.1-5(e)(4) using a Choice Mechanism (Sale) pursuant to the National Approach as defined in Section 1.81(b) of the MSPA, which incorporates the statutory provisions and regulations set forth below:<p></p>
-<ul>
- <li>Cal. Civ. Code 1798.135(a) or 1798.135(b) and 11 CCR 7025 or 7026</li>
-<li>Colo. Rev. Stat. 6-1-1306(1)(a)(III) or 6-1-1306(1)(a)(IV), and 4 CCR 904-3-4.03 and 5.03.</li>
-<li>Conn. Gen. Stat. § 42-520(1)(A)(e)(i) or (ii)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(e)</li>
-<li>Ind. Code Ann. § 24-15-3-1(a)</li>
-<li>Iowa Code § 715D.4(7)</li>
-<li>Kentucky Act, Sec. 4(5)</li>
-<li>Maryland Act 14–4605(C) or 14-46-6(A)(2)</li>
-<li>​​Minn. Stat. §§ 325O.07, Subd. 4(b) or 325O.05, Subd. 3(a)</li>
-<li>Montana Act, Sec. 6(3)(a) or (b)</li>
-<li>N.H. Rev. Stat. 507-H:6(V)(a)(1)(A) or N.H. Rev. Stat. 507-H:6(V)(a)(1)(B)</li>
-<li>Nebraska Act, Sec. 11(1) or 11(5)</li>
-<li>New Jersey Act, Sec. 3(b) or 8(b)</li>
-<li>Oregon Act, Sec. 5(5)</li>
-<li>Rhode Island Act 6-48.1-5(f)</li>
-<li>Tenn. Code Ann. 47-18-3304(a)</li>
-<li>Tex. Bus. & Com. Code § 541.055</li>
-<li>Utah Code 13-61-302(1)(b)(i)</li>
-<li>Virginia Code 59.1-578(D)</li>
-</ul>
-<code>0</code>  Not Applicable. SaleOptOutNotice value was not applicable or no notice was provided<p><code>1</code>  Opted Out<p><code>2</code>  Did Not Opt Out</td>
-</tr>
-<tr>
-<td>SharingOptOut</td>
-<td>Int(2)</td>
-<td>Consumer submitted a request to opt-out of the Sharing of the Consumer’s Personal Information pursuant to the National Approach as defined in Section 1.81(c) of the MSPA, which incorporates Cal. Civ. Code 1798.120(a) and 11 CCR 7026, using a Choice Mechanism (Share) pursuant to the National Approach as defined in Section 1.81(b) of the MSPA, which incorporates the statutory provisions and regulations set forth below:<p><p>
-<ul>
-<li>Cal. Civ. Code 1798.135(a) or 1798.135(b) and 11 CCR 7025 or 7026</li>
-</ul>
-<code>0</code>  Not Applicable. SharingOptOutNotice value was not applicable or no notice was provided.<p><code>1</code>  Opted Out<p><code>2</code>  Did Not Opt Out</td>
-</tr>
-<tr>
-<td>TargetedAdvertisingOptOut</td>
-<td>Int(2)</td>
-<td>Consumer submitted a request to opt out of the Processing of Personal Information for Targeted Advertising, pursuant to the National Approach as defined in Section 1.81(c) of the MSPA, which incorporates Virginia Code 59.1-577(A)(5)(i), Colo. Rev. Stat. 6-1-1306(1)(a)(I)(A), Utah Code 13-61-201(4)(a), Conn. Gen. Stat. § 42-518(a), Iowa Code § 715D.4(6), Ind. Code Ann. § 24-15-3-1(b)(5), Tenn. Code Ann. 47-18-3304(a)(2)(E)(ii), Tex. Bus. &amp; Com. Code § 541.055(b)(5)(A), Montana Act, Sec. 5(1)(e)(i), Oregon Act, Sec. 3(1)(d)(A), Del. Code Ann. tit. 6, § 12D-104(a)(6)(a),&nbsp; New Jersey Act, Sec. 7(a)(5), N.H. Rev. Stat. 507-H:4(I)(e), Nebraska Act, Sec. 7(e)(i), Kentucky Act, Sec. 3(2)(e), Minn. Stat. § 325O.05, Subd. 1(f), Maryland Act 14–4605(B)(7)(I), or Rhode Island Act 6-48.1-5(e)(4) using a Choice Mechanism (Targeted Advertising) pursuant to the National Approach as defined in Section 1.81(b) of the MSPA, which incorporates the statutory provisions and regulations set forth below:<p><p>
-<ul>
-<li>Colo. Rev. Stat. 6-1-1306(1)(a)(III) or 6-1-1306(1)(a)(IV), and 4 CCR 904-3-4.03 or 5.03.</li>
-<li>Conn. Gen. Stat. § 42-520(1)(A)(e)(i) or (ii)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(e)</li>
-<li>Ind. Code Ann. § 24-15-3-1(a)</li>
-<li>Iowa Code § 715D.4(7)</li>
-<li>Kentucky Act, Sec. 5(5)</li>
-<li>Maryland Act 14–4605(C) or 14-46-6(A)(2)</li>
-<li>Minn. Stat. §§ 325O.07, Subd. 1(b) or 325O.05, Subd. 3(a)</li>
-<li>Montana Act, Sec. 6(3)(a) or (b)</li>
-<li>N.H. Rev. Stat. 507-H:6(V)(a)(1)(A) or N.H. Rev. Stat. 507-H:6(V)(a)(1)(B)</li>
-<li>Nebraska Act, Sec. 11(1) or 11(5)</li>
-<li>New Jersey Act, Section 3(b) or 8(b)</li>
-<li>Oregon Act, Sec. 5(5)</li>
-<li>Rhode Island Act 6-48.1-5(f)</li>
-<li>Tenn. Code Ann. 47-18-3304(a)</li>
-<li>Tex. Bus. & Com. Code § 541.055</li>
-<li>Utah Code 13-61-302(1)(b)(ii)</li>
-<li>Virginia Code 59.1-578(D)</li>
-</ul>
-<code>0</code>  Not Applicable. TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided<p><code>1</code>  Opted Out<p><code>2</code>  Did Not Opt Out</td>
-</tr>
-<tr>
-<td>SensitiveDataProcessing</td>
-<td>N-Bitfield(2,16)</td>
-<td><p>For the specific category of Sensitive Personal Information that is identified in the String Component, have you obtained Consent from the Consumer to Process his or her Sensitive Personal Information in a way that adheres to requirements of an optional addendum to the MSPA that IAB may, in the future, promulgate to govern the Processing of Sensitive Personal Information by Signatories and Certified Partners for Digital Advertising Activities as provided in Section 1.28 of the MSPA, which will incorporate the statutory provisions and regulations set forth below?&nbsp;</p>
-<p>Two bits for each Data Activity:</p><code>0</code>  Not Applicable. The Business does not Process the specific category of Sensitive Data.<p><code>1</code> No Consent<p><code>2</code>  Consent&nbsp;<p>
-<p>(1) Consent to Process the Consumer’s Sensitive Personal Information Consisting of Personal Information Revealing Racial or Ethnic Origin.<p><p>References:
-<ul>
-<li>Cal. Civ. Code 1798.121(a) and 11 CCR 7027</li>
-<li>Colo. Rev. Stat. 6-1-1308(7) and 4 CCR 904-3-6.10.</li>
-<li>Conn. Gen. Stat. § 42-520(a)(4)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(a)(4)</li>
-<li>Ind. Code Ann. § 24-15-4-1(5)</li>
-<li>Iowa Code § 715D.4(2)</li>
-<li>Kentucky Act, Sec. 4(1)(e)</li>
-<li>Minn. Stat. § 325O.07, Subd. 2(d)</li>
-<li>Montana Act, Sec. 7(2)(b)</li>
-<li>N.H. Rev. Stat. 507-H:6(I)(d)</li>
-<li>Nebraska Act, Sec. 12(2)(d)</li>
-<li>New Jersey Act, Sec. 9(a)(4)</li>
-<li>Oregon Act, Sec. 5(2)(b)</li>
-<li>Rhode Island Act 6-48.1-4(c)</li>
-<li>Tenn. Code Ann. 47-18-3305(a)(6)</li>
-<li>Tex. Bus. & Com. Code § 541.101(b)(4)</li>
-<li>Utah Code 13-61-302(3)(a)</li>
-<li>Virginia Code 59.1-578(A)(5)</li>
-</ul>
-(2) Consent to Process the Consumer’s Sensitive Personal Information Consisting of Personal Information Revealing Religious or Philosophical Beliefs.<p><p>References:
-<ul>
-<li>Cal. Civ. Code 1798.121(a) and 11 CCR 7027</li>
-<li>Colo. Rev. Stat. 6-1-1308(7) and 4 CCR 904-3-6.10.</li>
-<li>Conn. Gen. Stat. § 42-520(a)(4)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(a)(4)</li>
-<li>Ind. Code Ann. § 24-15-4-1(5)</li>
-<li>Iowa Code § 715D.4(2)</li>
-<li>Kentucky Act, Sec. 4(1)(e)</li>
-<li>Minn. Stat. § 325O.07, Subd. 2(d)</li>
-<li>Montana Act, Sec. 7(2)(b)</li>
-<li>N.H. Rev. Stat. 507-H:6(I)(d)</li>
-<li>Nebraska Act, Sec. 12(2)(d)</li>
-<li>New Jersey Act, Sec. 9(a)(4)</li>
-<li>Oregon Act, Sec. 5(2)(b)</li>
-<li>Rhode Island Act 6-48.1-4(c)</li>
-<li>Tenn. Code Ann. 47-18-3305(a)(6)</li>
-<li>Tex. Bus. & Com. Code § 541.101(b)(4)</li>
-<li>Utah Code 13-61-302(3)(a)</li>
-<li>Virginia Code 59.1-578(A)(5)</li>
-</ul>
-(3) Consent to Process the Consumer’s Personal Information Consisting of Personal Information Concerning a Consumer’s Health (including a Mental or Physical Health Condition or Diagnosis; Medical History; pregnancy; or Medical Treatment or Diagnosis by a Health Care Professional).<p><p>References:
-<ul>
-<li>Cal. Civ. Code 1798.121(a) and 11 CCR 7027</li>
-<li>Colo. Rev. Stat. 6-1-1308(7) and 4 CCR 904-3-6.10.</li>
-<li>Conn. Gen. Stat. § 42-520(a)(4)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(a)(4)</li>
-<li>Ind. Code Ann. § 24-15-4-1(5)</li>
-<li>Iowa Code § 715D.4(2)</li>
-<li>Kentucky Act, Sec. 4(1)(e)</li>
-<li>Minn. Stat. § 325O.07, Subd. 2(d)</li>
-<li>Montana Act, Sec. 7(2)(b)</li>
-<li>N.H. Rev. Stat. 507-H:6(I)(d)</li>
-<li>Nebraska Act, Sec. 12(2)(d)</li>
-<li>New Jersey Act, Sec. 9(a)(4)</li>
-<li>Oregon Act, Sec. 5(2)(b)</li>
-<li>Rhode Island Act 6-48.1-4(c)</li>
-<li>Tenn. Code Ann. 47-18-3305(a)(6)</li>
-<li>Tex. Bus. & Com. Code § 541.101(b)(4)</li>
-<li>Utah Code 13-61-302(3)(a)</li>
-<li>Virginia Code 59.1-578(A)(5)</li>
-</ul>
-(4) Consent to Process the Consumer’s Personal Information Consisting of Personal Information Revealing Sex Life, Sexual Orientation, or Sexuality.<p><p>References:
-<ul>
-<li>Cal. Civ. Code 1798.121(a) and 11 CCR 7027</li>
-<li>Colo. Rev. Stat. 6-1-1308(7) and 4 CCR 904-3-6.10</li>
-<li>Conn. Gen. Stat. § 42-520(a)(4)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(a)(4)</li>
-<li>Ind. Code Ann. § 24-15-4-1(5)</li>
-<li>Iowa Code § 715D.4(2)</li>
-<li>Kentucky Act, Sec. 4(1)(e)</li>
-<li>Minn. Stat. § 325O.07, Subd. 2(d)</li>
-<li>Montana Act, Sec. 7(2)(b)</li>
-<li>N.H. Rev. Stat. 507-H:6(I)(d)</li>
-<li>Nebraska Act, Sec. 12(2)(d)</li>
-<li>New Jersey Act, Sec. 9(a)(4)</li>
-<li>Oregon Act, Sec. 5(2)(b)</li>
-<li>Rhode Island Act 6-48.1-4(c)</li>
-<li>Tenn. Code Ann. 47-18-3305(a)(6)</li>
-<li>Tex. Bus. & Com. Code § 541.101(b)(4)</li>
-<li>Utah Code 13-61-302(3)(a)</li>
-<li>Virginia Code 59.1-578(A)(5)</li>
-</ul>
-(5) Consent to Process the Consumer’s Personal Information Consisting of Personal Information Revealing Citizenship or Immigration Status.<p><p>References:
-<ul>
-<li>Cal. Civ. Code 1798.121(a) and 11 CCR 7027</li>
-<li>Colo. Rev. Stat. 6-1-1308(7) and 4 CCR 904-3-6.10</li>
-<li>Conn. Gen. Stat. § 42-520(a)(4)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(a)(4)</li>
-<li>Ind. Code Ann. § 24-15-4-1(5)</li>
-<li>Iowa Code § 715D.4(2)</li>
-<li>Kentucky Act, Sec. 4(1)(e)</li>
-<li>Minn. Stat. § 325O.07, Subd. 2(d)</li>
-<li>Montana Act, Sec. 7(2)(b)</li>
-<li>N.H. Rev. Stat. 507-H:6(I)(d)</li>
-<li>Nebraska Act, Sec. 12(2)(d)</li>
-<li>New Jersey Act, Sec. 9(a)(4)</li>
-<li>Oregon Act, Sec. 5(2)(b)</li>
-<li>Rhode Island Act 6-48.1-4(c)</li>
-<li>Tenn. Code Ann. 47-18-3305(a)(6)</li>
-<li>Tex. Bus. & Com. Code § 541.101(b)(4)</li>
-<li>Utah Code 13-61-302(3)(a)</li>
-<li>Virginia Code 59.1-578(A)(5)</li>
-</ul>
-(6) Consent to Process the Consumer’s Personal Information Consisting of Genetic Data for the Purpose of Uniquely Identifying an Individual / Natural Person.<p><p>References:
-<ul>
-<li>Cal. Civ. Code 1798.121(a) and 11 CCR 7027</li>
-<li>Colo. Rev. Stat. 6-1-1308(7) and 4 CCR 904-3-6.10</li>
-<li>Conn. Gen. Stat. § 42-520(a)(4)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(a)(4)</li>
-<li>Ind. Code Ann. § 24-15-4-1(5)</li>
-<li>Iowa Code § 715D.4(2)</li>
-<li>Kentucky Act, Sec. 4(1)(e)</li>
-<li>Minn. Stat. § 325O.07, Subd. 2(d)</li>
-<li>Montana Act, Sec. 7(2)(b)</li>
-<li>N.H. Rev. Stat. 507-H:6(I)(d)</li>
-<li>Nebraska Act, Sec. 12(2)(d)</li>
-<li>New Jersey Act, Sec. 9(a)(4)</li>
-<li>Oregon Act, Sec. 5(2)(b)</li>
-<li>Rhode Island Act 6-48.1-4(c)</li>
-<li>Tenn. Code Ann. 47-18-3305(a)(6)</li>
-<li>Tex. Bus. & Com. Code § 541.101(b)(4)</li>
-<li>Utah Code 13-61-302(3)(a)</li>
-<li>Virginia Code 59.1-578(A)(5)</li>
-</ul>
-(7) Consent to Process the Consumer’s Personal Information Consisting of Biometric Data for the Purpose of Uniquely Identifying an Individual / Natural Person.<p><p>References:
-<ul>
-<li>Cal. Civ. Code 1798.121(a) and 11 CCR 7027</li>
-<li>Colo. Rev. Stat. 6-1-1308(7) and 4 CCR 904-3-6.10</li>
-<li>Conn. Gen. Stat. § 42-520(a)(4)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(a)(4)</li>
-<li>Ind. Code Ann. § 24-15-4-1(5)</li>
-<li>Iowa Code § 715D.4(2)</li>
-<li>Kentucky Act, Sec. 4(1)(e)</li>
-<li>Minn. Stat. § 325O.07, Subd. 2(d)</li>
-<li>Montana Act, Sec. 7(2)(b)</li>
-<li>N.H. Rev. Stat. 507-H:6(I)(d)</li>
-<li>Nebraska Act, Sec. 12(2)(d)</li>
-<li>New Jersey Act, Sec. 9(a)(4)</li>
-<li>Oregon Act, Sec. 5(2)(b)</li>
-<li>Rhode Island Act 6-48.1-4(c)</li>
-<li>Tenn. Code Ann. 47-18-3305(a)(6)</li>
-<li>Tex. Bus. & Com. Code § 541.101(b)(4)</li>
-<li>Utah Code 13-61-302(3)(a)</li>
-<li>Virginia Code 59.1-578(A)(5)</li>
-</ul>
-(8) Consent to Process the Consumer’s Personal Information Consisting of Precise Geolocation Data.<p><p>References:
-<ul>
-<li>Cal. Civ. Code 1798.121(a) and 11 CCR 7027</li>
-<li>Conn. Gen. Stat. § 42-520(a)(4)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(a)(4)</li>
-<li>Ind. Code Ann. § 24-15-4-1(5)</li>
-<li>Iowa Code § 715D.4(2)</li>
-<li>Kentucky Act, Sec. 4(1)(e)</li>
-<li>Minn. Stat. § 325O.07, Subd. 2(d)</li>
-<li>Montana Act, Sec. 7(2)(b)</li>
-<li>N.H. Rev. Stat. 507-H:6(I)(d)</li>
-<li>Nebraska Act, Sec. 12(2)(d)</li>
-<li>New Jersey Act, Sec. 9(a)(4)</li>
-<li>Oregon Act, Sec. 5(2)(b)</li>
-<li>Rhode Island Act 6-48.1-4(c)</li>
-<li>Tenn. Code Ann. 47-18-3305(a)(6)</li>
-<li>Tex. Bus. & Com. Code § 541.101(b)(4)</li>
-<li>Utah Code 13-61-302(3)(a)</li>
-<li>Virginia Code 59.1-578(A)(5)</li>
-</ul>
-(9) Consent to Process the Consumer’s Personal Information Consisting of a Consumer’s Social Security, Driver’s License, State Identification Card, or Passport Number.<p><p>References:
-<ul>
-<li>Cal. Civ. Code 1798.121(a) and 11 CCR 7027</li>
-</ul>
-(10) Consent to Process the Consumer’s Personal Information Consisting of a Consumer’s Account Log-In, Financial Account, Debit Card, or Credit Card Number in Combination with Any Required Security or Access Code, Password, or Credentials Allowing Access to an Account.<p><p>References:
-<ul>
-<li>Cal. Civ. Code 1798.121(a) and 11 CCR 7027</li>
-<li>New Jersey Act, Sec. 9(a)(4)</li>
-</ul>
-(11) Consent to Process the Consumer’s Personal Information Consisting of Union Membership.<p><p>References:
-<ul>
-<li>Cal. Civ. Code 1798.121(a) and 11 CCR 7027</li>
-</ul>
-(12) Consent to Process the Consumer’s Personal Information Consisting of the contents of a Consumer’s Mail, Email, and Text Messages unless You Are the Intended Recipient of the Communication.<p><p>References:
-<ul>
-<li>Cal. Civ. Code 1798.121(a) and 11 CCR 7027</li>
-</ul>
-(13) Consent to Process Consumer Health Data about the Consumer.<p></p>References:
-<ul>
-<li>Conn. Gen. Stat. § 42-520(a)(4)</li>  
-</ul>
-(14) Consent to Process Data Concerning the Consumer’s Status as a Victim of Crime.<p></p>References:
-<ul>
-<li>Conn. Gen. Stat. § 42-520(a)(4)</li>
-<li>Oregon Act, Sec. 5(2)(b)</li>
-</ul>
-(15) Consent to Process the Consumer’s Sensitive Personal Information Consisting of Personal Information Revealing National Origin.<p></p>References:
-<ul>
-<li>Oregon Act, Sec. 5(2)(b)</li>
-</ul>
-(16) Consent to Process the Consumer’s Sensitive Personal Information Consisting of Personal Information Revealing Status as Transgender or Nonbinary.<p></p>References:
-<ul>
-<li>Oregon Act, Sec. 5(2)(b)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(a)(4)</li>
-<li>New Jersey Act, Sec. 9(a)(4)</li>  
-</ul>
+<td>First Party provided notice pursuant to Section 4.3 of the MSPA
+<p><code>1</code> No, notice was not provided because the First Party does not Sell or Share Personal Information</p>
+<p><code>2</code> Yes, notice was provided</p> 
 </td>
 </tr>
 <tr>
-<td>KnownChildSensitiveDataConsents</td>
-<td>N-Bitfield(2,3)</td>
-<td>Consent from the Consumer to Process his or her Personal Information or Sensitive Personal Information in a way that adheres to requirements of an optional addendum to the MSPA that IAB may, in the future, promulgate to govern the Processing of Minor Information by Signatories and Certified Partners for Digital Advertising Activities as provided in Section 1.28 of the MSPA, which will incorporate the statutory provisions and regulations set forth below.<p></p>
-<p>Two bits for each Data Activity:</p>
-<code>0</code>  Not Applicable. The Business does not have actual knowledge that it Processes Personal Data or Sensitive Data of a Consumer who is a known child.<p><code>1</code> No Consent<p><code>2</code> Consent&nbsp;
-<p>(1) Consent to Process the Consumer’s Personal Information or Sensitive Personal Information for Consumers from Age 13 to 16.<p><p>References:
-<ul>
-<li>Cal. Civ. Code 1798.120(c) and 11 CCR 7070-7071</li>
-<li>Conn. Gen. Stat. § 42-520(a)(7)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(a)(7)</li>
-<li>Montana Act, Sec. 7(2)(d)</li>
-<li>N.H. Rev. Stat. 507-H:6(I)(g)</li>
-<li>New Jersey Act, Sec. 9(a)(7)</li>
-<li>Oregon Act, Sec. 5(2)(b)</li>
-</ul>
-(2) Consent to Process the Consumer’s Personal Information or Sensitive Personal Information for Consumers Younger Than 13 Years of Age.<p><p>References:
-<ul>
-<li>Cal. Civ. Code 1798.120(c) and 11 CCR 7070-7071</li>
-<li>Colo. Rev. Stat. 6-1-1308(7) and 4 CCR 904-3-7.06</li>
-<li>Conn. Gen. Stat. § 42-520(a)(4)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(a)(4)</li>
-<li>Ind. Code Ann. § 24-15-4-1(5)</li>
-<li>Iowa Code § 715D.4(2)</li>
-<li>Kentucky Act, Sec. 4(1)(e)</li>
-<li>Minn. Stat. § 325O.07, Subd. 2(d)</li>
-<li>Montana Act, Sec. 7(2)(b)</li>
-<li>N.H. Rev. Stat. 507-H:6(I)(d)</li>
-<li>Nebraska Act, Sec. 12(2)(d)</li>
-<li>New Jersey Act, Sec. 9(a)(4)</li>
-<li>Oregon Act, Sec. 5(2)(b)</li>
-<li>Rhode Island Act 6-48.1-4(c)</li>
-<li>Tenn. Code Ann. 47-18-3305(a)(6)</li>
-<li>Tex. Bus. &amp; Com. Code § 541.101(b)(4)</li>
-<li>Utah Code 13-61-302(3)(a)</li>
-<li>Virginia Code 59.1-578(A)(5)</li>
-</ul>
-(3) Consent to Process the Consumer’s Personal Information or Sensitive Personal Information for Consumers from Age 16 to 17.<p><p>References:
-<ul>
-<li>Del. Code Ann. tit. 6, § 12D-106(a)(4)</li>
-<li>New Jersey Act, Sec. 9(a)(7)</li>
-</ul>
+<td><code>MspaOptOut</code></td>
+<td>Int(2)</td>
+<td>Consumer submitted a request to Opt Out pursuant to the Choice Mechanisms provided under Section 4.4 of the MSPA.
+<p><code>0</code> Not applicable because the First Party does not Sell or Share Personal Information or Process Personal Information for Targeted Advertising.</p>
+<p><code>1</code> Consumer Opted Out</p> 
+<p><code>2</code> Consumer Did Not Opt Out </p> 
 </td>
 </tr>
 <tr>
-<td>PersonalDataConsents</td>
-<td>Int(2)</td>
-<td>Consumer Consented to the Processing of the Consumer’s Personal Information for Digital Advertising Activities that would, but for providing Consent, not otherwise meet the Secondary Use Limitations.&nbsp; The Secondary Use Limitations, as set forth in the National Approach, incorporate the statutory provisions and regulations set forth below:<p><p>References:
-<ul><li>Cal. Civ. Code 1798.100(c) and 11 CCR 7002</li>
-<li>Colo. Rev. Stat. 6-1-1308(4) and 4 CCR 904-3-6.08</li>
-<li>Conn. Gen. Stat. § 42-520(a)(2)</li>
-<li>Del. Code Ann. tit. 6, § 12D-106(a)(2)</li>
-<li>Ind. Code Ann. § 24-15-4-1(2)</li>
-<li>Kentucky Act, Sec. 4(1)(b)</li>
-<li>Minn. Stat. § 325O.07, Subd. 2(b)</li>
-<li>Montana Act, Sec. 7(2)(a)</li>
-<li>N.H. Rev. Stat. 507-H:6(I)(b)</li>
-<li>Nebraska Act, Sec. 12(2)(a)</li>
-<li>New Jersey Act, Sec. 9(a)(2)</li>
-<li>Oregon Act, Sec. 5(1)(a) and 5(2)(a)</li>
-<li>Tenn. Code Ann. 47-18-3305(a)(2)</li>
-<li>Tex. Bus. &amp; Com. Code § 541.101(b)(1)</li>
-<li>Virginia Code 59.1-578(A)(2)</li>
-</ul>
-<code>0</code>  Not Applicable. The Business does not Process the Consumer’s Personal Data for advertising purposes that are not reasonably necessary for nor compatible with the disclosed purpose for which the Consumer’s Personal Data was processed.<p><code>1</code> No Consent<p><code>2</code> Consent&nbsp;</td>
-</tr>
-<tr>
-<td>MspaCoveredTransaction</td>
-<td>Int(2)</td>
-<td>Publisher or Advertiser, as applicable, is a signatory to the IAB Multistate Service Provider Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.<p><code>1</code>  Yes<p><code>2</code>  No</td>
-</tr>
-<tr>
-<td>MspaOptOutOptionMode</td>
-<td>Int(2)</td>
-<td>Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.<p><code>0</code>  Not Applicable.<p><code>1</code>  Yes<p><code>2</code>  No</td>
-</tr>
-<tr>
-<td>MspaServiceProviderMode</td>
-<td>Int(2)</td>
-<td>Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.<p><code>0</code>  Not Applicable<p><code>1</code>  Yes<p><code>2</code>  No</td>
+<td><code>MspaId</code></td>
+<td>Int(14)</td>
+<td>The MSPA identifier from the First Party where the string originates.
+</td>
 </tr>
 </tbody>
 </table>
 </div>
 
-<h4 id="gpc-subsection">GPC Sub-section</h4>
-<p><a href="https://globalprivacycontrol.github.io/gpc-spec/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPC Subsections should check whether GPC is set and pass along the value from the headers or javascript API in this subsection. Refer to the </span><a target="_blank" rel="noopener noreferrer nofollow" href="https://privacycg.github.io/gpc-spec/"><span style="color: rgb(17, 85, 204)">GPC specifications</span></a><span style="color: rgb(36, 41, 47)"> for details on GPC including how to handle conflicts or inconsistencies.</span>
-</p>
+<h4 id="gpc-subsection">GPC Subsection</h4>
+<p><a href="https://w3c.github.io/gpc/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings must check for whether GPC is set and pass along the signal they find (from the headers or javascript API) in this subsection. The GPC subsection must always be present.</p>
 
 <table>
 <thead>
@@ -566,12 +181,12 @@ Implementers should employ the MSPA US National Privacy Section to adhere to the
 </thead>
 <tbody>
 <tr>
-<td style="text-align:left">SubsectionType</td>
+<td style="text-align:left"><code>SubsectionType</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left"><p><code>0</code> Core<p><code>1</code> GPC</td>
+<td><code>1</code> GPC</td>
 </tr>
 <tr>
-<td style="text-align:left">Gpc</td>
+<td style="text-align:left"><code>Gpc</td>
 <td style="text-align:left">Boolean</td>
 <td style="text-align:left"><p><code>0</code> false<p><code>1</code> true</td>
 </tr>

--- a/Sections/US-National/README.md
+++ b/Sections/US-National/README.md
@@ -1,29 +1,37 @@
 <h1 id="gpp-extension-iab-privacy-s-national-privacy-technical-specification">IAB Privacy’s Multi-State Privacy Agreement (MSPA) US National Technical Specification</h1>
 
-<h3><span style="color: rgb(67, 67, 67)">Multi-State Privacy Agreement (MSPA) US National Technical Specification</span></h3>
-<p>Contained in this directory are technical specifications for the Multi-State Privacy Agreement (MSPA) US National Section of the GPP to support the “US National Approach” as defined in the MSPA. <strong>Implementers intending to support the MSPA section should begin by reading the </strong><a target="_blank" rel="noopener noreferrer nofollow" href="https://docs.google.com/document/d/1iBiCCDLUsi7RjZ03wxtlULbq_91Wb3AzdaBDFylpMVs/edit#heading=h.fy2mjfdw3m58"><span style="color: rgb(17, 85, 204)"><strong>MSPA</strong></span></a><strong>.</strong>
+<h3>Multi-State Privacy Agreement (MSPA) US National Technical Specification</h3>
+<p>Contained in this directory are technical specifications for the Multi-State Privacy Agreement (MSPA) US National Section of the <a target="_blank" rel="noopener noreferrer nofollow" href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform "> Global Privacy Protocol (GPP)</a>
+to support the “US National Approach” as defined in the MSPA. <strong>Implementers intending to support the MSPA section should begin by reading the </strong><a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/">MSPA</a>.</strong>
 </p>
-<h3><span style="color: rgb(67, 67, 67)">What is the Multi-State Privacy Agreement (MSPA)?</span></h3>
-<p>The <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/"><span style="color: rgb(17, 85, 204)">Multi-State Privacy Agreement (MSPA)</span></a> is a contractual framework developed for the industry, which is intended to aid advertisers, publishers, agencies, and ad-tech intermediaries in complying with the new state privacy laws.</p>
-<p>It is an agreement between all signatories and functions as a “springing contract” which supplements commercial contracts amongst signatories with required privacy-related contractual terms. Where no commercial contracts exist, the MSPA provides the required baseline set of privacy-related contractual terms.&nbsp;</p>
-<h3><span style="color: rgb(67, 67, 67)">What is the MSPA US National Section?</span></h3>
-<p>The MSPA US National Privacy Section provides a way for <a target="_blank" rel="noopener noreferrer nofollow" href="https://tools.iabtechlab.com/transparencycenter/explorer/business/mspa"><span style="color: rgb(17, 85, 204)">MSPA signatories</span></a> and <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/cpp.html"><span style="color: rgb(17, 85, 204)">Certified Partners</span></a> to meet the highest common denominator of state privacy law requirements <span style="color: rgb(68, 71, 70)">&nbsp;</span>and are used in place of specific state strings for MSPA covered transactions.</p>
-<p>There is no federal privacy law and it is important to note that the MSPA US National Section does not reflect US federal legal requirements; its purpose is to support compliance with applicable US State privacy laws. To understand the states covered by the MSPA US National Section, refer to the <a target="_blank" rel="noopener noreferrer nofollow" href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/US-National/IAB%20Privacy%E2%80%99s%20National%20Privacy%20Technical%20Specification.md#version-history"><span style="color: rgb(17, 85, 204)">version history</span></a> in the technical specifications.</p>
-<h3><span style="color: rgb(67, 67, 67)">Who can declare a covered transaction and use the MSPA US National Section?</span></h3>
-<p>The requirements of the signal in the MSPA US National Privacy Section are defined and governed by the MSPA, which is a common agreement by all signatories to interpret the section signal consistently and according to the MSPA, and intended for the facilitation of transactions by its signatories. Covered transactions in this section should only be used by MSPA signatories.&nbsp;</p>
-<h3><span style="color: rgb(67, 67, 67)">Where is the MSPA US National Section defined?</span></h3>
-<p>The MSPA US National Section is defined within the MSPA Contractual Framework and its accompanying technical implementation guidelines. In the Contractual Framework, the specific section defining the US National Approach is outlined in <a target="_blank" rel="noopener noreferrer nofollow" href="https://iabtechlab.com/wp-content/uploads/2024/01/IAB-Second-Amended-and-Restated-Multi-State-Privacy-Agreement-MSPA.pdf"><span style="color: rgb(0, 120, 215)">Section 1.81 "U.S. National Approach"</span></a>, located on page 12.</p>
-<p>For additional guidance, the MSPA technical implementation guidelines offer detailed instructions on usage of the MSPA US National Section. Specifically, <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/IAB%20MSPA%20Technical%20Signaling%20Implementation%20Guidelines%20v1.2.pdf"><span style="color: rgb(0, 120, 215)">Section 4.3 "U.S. National Consumers"</span></a>, on page 11, elaborates on signaling requirements pertinent to the MSPA US National Section.&nbsp;</p>
-<p>Please reference both the <a target="_blank" rel="noopener noreferrer nofollow" href="https://iabtechlab.com/wp-content/uploads/2024/01/IAB-Second-Amended-and-Restated-Multi-State-Privacy-Agreement-MSPA.pdf"><span style="color: rgb(17, 85, 204)">MSPA Contractual Framework</span></a> and the <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/IAB%20MSPA%20Technical%20Signaling%20Implementation%20Guidelines%20v1.2.pdf"><span style="color: rgb(17, 85, 204)">MSPA Technical Signaling Implementation Guidelines</span></a> for a comprehensive understanding of the MSPA US National Section.</p>
-<h3><span style="color: rgb(67, 67, 67)">Where can I access the list of MSPA signatories?</span></h3>
-<p>You can review the list of MSPA signatories and certified partners in the IAB Tech Lab Tools Portal: <a target="_blank" rel="noopener noreferrer nofollow" href="https://tools.iabtechlab.com/transparencycenter/explorer/business/mspa"><span style="color: rgb(17, 85, 204)">MSPA Identification List</span></a>
+
+<h3>What is the Multi-State Privacy Agreement (MSPA)?</h3>
+<p>The <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/">Multi-State Privacy Agreement (MSPA)</a> is a contractual framework developed by the industry, which is intended to aid advertisers, publishers, agencies, and ad-tech intermediaries in complying with state privacy laws.</p>
+<p>It is an agreement between all signatories and functions as a “springing contract” which supplements commercial contracts amongst signatories with required privacy-related contractual terms. Where no commercial contracts exist, the MSPA provides the required baseline set of privacy-related contractual te.</p>
+
+<h3>What is the MSPA US National Section?</h3>
+<p>The MSPA US National Privacy Section provides a way for <a target="_blank" rel="noopener noreferrer nofollow" href="https://tools.iabtechlab.com/transparencycenter/explorer/business/mspa">MSPA signatories</a> and <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/cpp.html">Certified Partners</a> to meet the highest common denominator of state privacy law requirements using a single, common signal.</p>
+
+<p>There is no federal omnibus privacy law and the MSPA US National Section therefore does not reflect US federal legal requirements; its purpose is to provide generalized support for compliance with applicable US State consumer privacy laws. For a list of states covered by the MSPA US National Section, refer to the <a target="_blank" rel="noopener noreferrer nofollow" href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/US-National/IAB%20Privacy%E2%80%99s%20Multi-State%20Privacy%20Agreement%20(MSPA)%20US%20National%20Technical%20Specification.md#version-history">version history</a> in the technical specifications.</p>
+
+<h3>Who can declare a Covered Transaction and use the MSPA US National Section?</h3>
+<p>Signatories' requirements when sending or receiving signals under the MSPA US National Section are set forth in the MSPA, which is a common agreement by all signatories to interpret the section signal consistently and according to the MSPA, and intended for the facilitation of transactions by its signatories. The MSPA US National Section signals must be used only by MSPA signatories.</p>
+
+<h3>Where is the MSPA US National Section defined?</h3>
+<p>The MSPA US National Section is defined within the MSPA and its accompanying technical implementation guidelines. In the MSPA, Section 4 and 5 govern how signals must be processed under the MSPA US National Approach. 
+
+<p>For additional guidance, the <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/IAB%20MSPA%20Technical%20Signaling%20Implementation%20Guidelines%20v1.5%20(03.05.2026).pdf">MSPA Technical Signaling Implementation Guidelines</a> offer detailed instructions on usage of the MSPA US National Section. Please review both the <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/">MSPA</a> and the <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/IAB%20MSPA%20Technical%20Signaling%20Implementation%20Guidelines%20v1.5%20(03.05.2026).pdf">MSPA Technical Signaling Implementation Guidelines</a> for a comprehensive understanding of the MSPA US National Section.</p>
+
+<h3>Where can I access the list of MSPA signatories?</h3>
+<p>You can review the list of MSPA signatories and certified partners in the IAB Tech Lab Tools Portal: <a target="_blank" rel="noopener noreferrer nofollow" href="https://tools.iabtechlab.com/transparencycenter/explorer/business/mspa">MSPA Identification List</a>
 </p>
-<h3><span style="color: rgb(67, 67, 67)">Where can I access MSPA resources?</span></h3>
-<p>You can access a variety of MSPA resources by visiting: <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/"><span style="color: rgb(17, 85, 204)">https://www.iabprivacy.com/</span></a> which provides materials to assist in understanding and implementing the MSPA framework. Some of the resources available include:&nbsp;</p>
+
+<h3>Where can I access MSPA resources?</h3>
+<p>You can access a variety of MSPA resources by visiting: <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/">https://www.iabprivacy.com</a> which provides materials to assist in understanding and implementing the MSPA framework. Some of the resources available include:</p>
 <ul>
-    <li>MSPA downloadable for reference</li>
     <li>MSPA registration information</li>
     <li>MSPA identification list</li>
-    <li>Explainer guides</li>
-    <li>Technical implementation guide</li>
+    <li>Current and past versions of the MSPA</li>
+    <li>Tech Vendor Data Processing Addendum to the MSPA</li>
+    <li>MSPA Technical Signaling Implementation Guidelines</li>
 </ul>

--- a/Sections/US-National/mspa list specification.md
+++ b/Sections/US-National/mspa list specification.md
@@ -1,0 +1,316 @@
+# MSPA Signatory List 
+
+The MSPA Signatory List is a technical document that any MSPA signatory can access to understand which partners are MSPA signatories. The MSPA Signatory List will be published in a standard location and updated weekly. 
+
+## Version History
+
+<table>
+<tbody>
+<tr>
+<td><strong>Date</strong></td>
+<td><strong>Version</strong></td>
+<td><strong>Comments</strong></td>
+</tr>
+<tr>
+<td>August 2026 <i>(Public Comment)</i></td>
+<td>2.0</td>
+<td>New spec</td>
+</tr>
+<tr>
+</tbody>
+</table>
+
+### Object: MSPA Signatory List
+<table>
+<tbody>
+<tr>
+<td><strong>Field</strong></td>
+<td><strong>Type</strong></td>
+<td><strong>Description</strong></td>
+</tr>
+<tr>
+<td><code>mspaListSpecVersion</code></td>
+<td>String; required</td>
+<td>The version of the MSPA Signatory List specification used.</td>
+</tr>
+<tr>
+<td><code>mspaVersion</code></td>
+<td>String; required</td>
+<td>The version of the MSPA that applies.</td>
+</tr>
+<tr>
+<td><code>listVersion</code></td>
+<td>Integer; required</td>
+<td>The version of the MSPA Signatory List. Incremented with each updated. Restarts at 1 when moving to a new mspaListSpecVersion</td>
+</tr>
+<tr>
+<td><code>lastUpdated</code></td>
+<td>String; required</td>
+<td>The ISO-8601 date and time this version of the file was published.</td>
+</tr>
+<tr>
+<td><code>certifiedPartners</code></td>
+<td>Object array</td>
+<td>Certified Partners list.</td>
+</tr>
+<tr>
+<td><code>signatories</code></td>
+<td>Object array</td>
+<td>MSPA signatories list.</td>
+</tr>
+</tbody>
+</table>
+
+### Object: Certified Partners
+<table>
+<tbody>
+<tr>
+<td><strong>Field</strong></td>
+<td><strong>Type</strong></td>
+<td><strong>Description</strong></td>
+</tr>
+<tr>
+<td><code>id</code></td>
+<td>String; required</td>
+<td>The unique identifier assigned to the Certified Partner.</td>
+</tr>
+<tr>
+<td><code>registrationTimestamp</code></td>
+<td>String; required</td>
+<td>The ISO-8601 date and time when the Certified Partner was registered.</td>
+</tr>
+<tr>
+<td><code>deletedTimestamp</code></td>
+<td>String</td>
+<td>The ISO-8601 date and time when the Certified Partner  was removed from the list.</td>
+</tr>
+<tr>
+<td><code>partnerName</code></td>
+<td>String; required</td>
+<td>The name of the Certified Partner.</td>
+</tr>
+<tr>
+<td><code>partnerProducts</code></td>
+<td>String array; required</td>
+<td>The products that are covered</td>
+</tr>
+</tbody>
+</table>
+
+### Object: Signatories
+<table>
+<tbody>
+<tr>
+<td><strong>Field</strong></td>
+<td><strong>Type</strong></td>
+<td><strong>Description</strong></td>
+</tr>
+<tr>
+<td><code>id</code></td>
+<td>String; required</td>
+<td>The unique identifier assigned to the participant upon registration.</td>
+</tr>
+<tr>
+<td><code>signatory</code></td>
+<td>Object array; required</td>
+<td>Information about the signatory.</td>
+</tr>
+</tbody>
+</table>
+
+### Object: Signatory
+<table>
+<tbody>
+<tr>
+<td><strong>Field</strong></td>
+<td><strong>Type</strong></td>
+<td><strong>Description</strong></td>
+</tr>
+<tr>
+<td><code>signatoryType</code></td>
+<td>String; required</td>
+<td>First Party Publisher, First Party Advertiser, Downstream Vendor</td>
+</tr>
+<tr>
+<td><code>registrationTimestamp</code></td>
+<td>String; required</td>
+<td>The ISO-8601 date and time when the signatory registered under this signatoryType</td>
+</tr>
+<tr>
+<td><code>deletedTimestamp</code></td>
+<td>String</td>
+<td>The ISO-8601 date and time when the signatory was removed under this signatoryType</td>
+</tr>
+<tr>
+<td><code>entityType</code></td>
+<td>String; required</td>
+<td>Company or individual</td>
+</tr>
+<tr>
+<td><code>name</code></td>
+<td>String; required</td>
+<td>Company legal name or name of individual</td>
+</tr>
+<tr>
+<td><code>coveredPropertiesWebsites</code></td>
+<td>Object array</td>
+<td>Websites that are covered. Only applicable when <code>signatoryType</code> is First Party Publisher or First Party Advertiser.</td>
+</tr>
+<tr>
+<td><code>coveredPropertiesApps</code></td>
+<td>Object array</td>
+<td>Apps that are covered. Only applicable when <code>signatoryType</code> is First Party Publisher or First Party Advertiser.</td>
+</tr>
+<tr>
+<td><code>domain</code></td>
+<td>String</td>
+<td>The domain name (e.g. the domain of the advertising system as referenced in ads.txt files when applicable). Only applicable when the <code>signatoryType</code> is Downstream Vendor.</td>
+</tr>
+<tr>
+<td><code>optOutUrls</code></td>
+<td>String array</td>
+<td>The URL where a consumer may opt out. This may be empty if the entity indicated that the company does not sell or share personal information. </td>
+</tr>
+</tbody>
+</table>
+
+### Object: Covered Properties Websites
+<table>
+<tbody>
+<tr>
+<td><strong>Field</strong></td>
+<td><strong>Type</strong></td>
+<td><strong>Description</strong></td>
+</tr>
+<tr>
+<td><code>property</code></td>
+<td>String</td>
+<td>The website that is covered</td>
+</tr>
+<tr>
+<td><code>optOutUrl</code></td>
+<td>String</td>
+<td>The URL where a consumer may opt out. This may be empty if the entity indicated that the company does not sell or share personal information. </td>
+</tr>
+</tbody>
+</table>
+
+### Object: Covered Properties Apps
+<table>
+<tbody>
+<tr>
+<td><strong>Field</strong></td>
+<td><strong>Type</strong></td>
+<td><strong>Description</strong></td>
+</tr>
+<tr>
+<td><code>property</code></td>
+<td>String</td>
+<td>The name of the app that is covered</td>
+</tr>
+<tr>
+<td><code>appId</code></td>
+<td>String</td>
+<td>The bundle id</td>
+</tr>
+<tr>
+<td><code>appStore</code></td>
+<td>String</td>
+<td>Apple, Google Play, Amazon, Samsung, Roku, Other</td>
+</tr>
+<tr>
+<td><code>optOutUrl</code></td>
+<td>String</td>
+<td>The URL where a consumer may opt out. This may be empty if the entity indicated that the company does not sell or share personal information. </td>
+</tr>
+</tbody>
+</table>
+
+#### Example JSON
+```json
+{
+   "mspaListSpecVersion": "2.0",
+   "mspaVersion": "5",
+   "listVersion": 1,
+   "lastUpdated": "2026-06-01T12:00:00Z",
+   "certifiedPartners": {
+       "2973": {
+           "id": "2973",
+           "registrationTimestamp": "2026-06-01T12:00:00Z",
+           "deletedTimestamp": "2026-06-01T12:00:00Z",
+           "partnerName": "Certified Partner Company",
+           "partnerProducts": ["Certified Partner Product 1", "Certified Partner Product 2"]
+           }
+           },
+   "signatories": {
+       "1234": {
+           "id": "1234",
+           "signatory": [
+               {
+                   "signatoryType": "First Party Publisher", // First Party Publisher, First Party Advertiser, Downstream Vendor
+                   "registrationTimestamp": "2026-06-01T12:00:00Z",
+                   "deletedTimestamp": "2026-06-01T12:00:00Z", // If present, entity is no longer an MSPA signatory after this date/time.
+                   "entityType": "Company", // Company or Individual
+                   "name" "Company", // Company legal name or name of individual
+                   "coverePropertiesWebsites": [
+                       {
+                           "property": "coveredwebsite1.com",
+                           "optOutUrl": "https://coveredwebsite1.com/optout" // Empty if company indicated that it does not sell or share personal information.
+                       },
+                                               {
+                           "property": "coveredwebsite2.com",
+                           "optOutUrl": "https://coveredwebsite2.com/optout" // Empty if company indicated that it does not sell or share personal information.
+                       }
+                   ],
+                   "coveredPropertiesApps": [
+                       {
+                           "property": "coveredapp1", // App name
+                           "appId": "1234",
+                           "appStore":"Apple", // Apple, Google Play, Amazon, Samsung, Roku, Other
+                           "optOutUrl": "https://coveredapp1.com/optout" // Empty if company indicated that it does not sell or share personal information.
+                       },
+                                               {
+                           "property": "coveredapp2",
+                           "appId": "5678",
+                           "appStore":"Google Play", // Apple, Google Play, Amazon, Samsung, Roku, Other
+                           "optOutUrl": "https://coveredapp2.com/optout" // Empty if company indicated that it does not sell or share personal information.
+                       }
+                   ]
+           },
+           {
+            "signatoryType": "First Party Advertiser", // First Party Publisher, First Party Advertiser, Downstream Vendor
+                   "registrationTimestamp": "2026-06-01T12:00:00Z",
+                   "deletedTimestamp": "2026-06-01T12:00:00Z", // If present, entity is no longer an MSPA signatory after this date/time.
+                   "entityType": "Company", // Company or Individual
+                   "name" "Company", // Company legal name or name of individual
+                   "coverePropertiesWebsites": [
+                       {
+                           "property": "coveredwebsite1.com",
+                           "optOutUrl": "https://coveredwebsite1.com/optout" // Empty if company indicated that it does not sell or share personal information.
+                       },
+                                               {
+                           "property": "coveredwebsite2.com",
+                           "optOutUrl": "https://coveredwebsite2.com/optout" // Empty if company indicated that it does not sell or share personal information.
+                       }
+                   ],
+                   "coveredPropertiesApps": [] // Empty if no apps are covered.
+                                         
+           },
+           {
+               "signatoryType": "Downstream Vendor", // First Party Publisher, First Party Advertiser, Downstream Vendor
+                   "registrationTimestamp": "2026-06-01T12:00:00Z",
+                   "deletedTimestamp": "2026-06-01T12:00:00Z", // If present, entity is no longer an MSPA signatory after this date/time.
+                   "entityType": "Company", // Company or Individual
+                   "name" "Company", // Company legal name or name of individual
+                   "domain": "downstreamvendor.com",
+                   "optOutUrls":[
+                       "downstreamvendor.com/optout1",
+                       "downstreamvendor.com/optout2"
+                   ]
+           }
+              
+           ]
+       }
+   }
+}
+```

--- a/Sections/US-States/CA/GPP Extension: California Privacy Technical Specification.md
+++ b/Sections/US-States/CA/GPP Extension: California Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-california-privacy-technical-specification">GPP Extension: California Privacy Technical Specification</h1>
+<h1 id="gpp-extension-california-privacy-technical-specification">California Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the California section of the GPP specification by those who (i) are Signatories to IAB Privacy, Inc.’s <a href=https://www.iabprivacy.com/>Multi-State Privacy Agreement (MSPA)</a>; and (ii) those who are not signatories of the MSPA.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the California section of the GPP.</p>
 
 
 <h3>Version History&nbsp;</h3>
@@ -12,7 +12,11 @@
 <td><strong>Version</strong></td>
 <td><strong>Comments</strong></td>
 </tr>
-
+<tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr>
 <tr>
 <td>December 2022</td>
 <td>1.0</td>
@@ -50,8 +54,8 @@
 </table>
 <h3 id="section-encoding">Section encoding</h3>
 <p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
-<h4 id="core-section">Core Sub-section</h4>
-<p>The core sub-section must always be present. Where terms are capitalized in the ‘description’ field they are defined terms in Cal. Civ. Code 1798.140. It consists of the following fields:
+<h4 id="core-section">Core Subsection</h4>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ field they are defined terms in Cal. Civ. Code 1798.140. It consists of the following fields:
 </p>
 <table>
 <thead>
@@ -63,71 +67,74 @@
 </thead>
 <tbody>
 <tr>
-<td style="text-align:left">Version</td>
+<td style="text-align:left"><code>Version</code></td>
 <td style="text-align:left">Int(6)</td>
 <td style="text-align:left">The version of this section specification used to encode the string.</td>
 </tr>
 <tr>
-<td style="text-align:left">SaleOptOutNotice</td>
+<td style="text-align:left"><code>SaleOptOutNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Opportunity to Opt Out of the Sale of the Consumer&#39;s Personal Information<p><code>0</code> Not Applicable. The Business does not Sell Personal Data.<p><code>1</code> Yes, notice was provided<p><code>2</code> No, notice was not provided</td>
 </tr>
 <tr>
-<td style="text-align:left">SharingOptOutNotice</td>
+<td style="text-align:left"><code>SharingOptOutNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Opportunity to Opt Out of the Sharing of the Consumer&#39;s Personal Information<p><code>0</code> Not Applicable.The Business does not Share Personal Data.<p><code>1</code> Yes, notice was provided<p><code>2</code> No, notice was not provided</td>
 </tr>
 <tr>
-<td style="text-align:left">SensitiveDataLimitUseNotice</td>
+<td style="text-align:left"><code>SensitiveDataLimitUseNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Opportunity to Limit Use or Disclosure of the Consumer&#39;s Sensitive Personal Information<p><code>0</code> Not Applicable. The Business does not use or disclose Sensitive Data.<p><code>1</code> Yes, notice was provided<p><code>2</code> No, notice was not provided</td>
 </tr>
 <tr>
-<td style="text-align:left">SaleOptOut</td>
+<td style="text-align:left"><code>SaleOptOut</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Opt-Out of the Sale of the Consumer&#39;s Personal Information<p><code>0</code> Not Applicable. SaleOptOutNotice value was not applicable or no notice was provided<p><code>1</code> Opted Out<p><code>2</code> Did Not Opt Out</td>
 </tr>
 <tr>
-<td style="text-align:left">SharingOptOut</td>
+<td style="text-align:left"><code>SharingOptOut</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Opt-Out of the Sharing of the Consumer&#39;s Personal Information<p><code>0</code> Not Applicable. SharingOptOutNotice value was not applicable or no notice was provided.<p><code>1</code> Opted Out<p><code>2</code> Did Not Opt Out</td>
 </tr>
 <tr>
-<td style="text-align:left">SensitiveDataProcessing</td>
+<td style="text-align:left"><code>SensitiveDataProcessing</code></td>
 <td style="text-align:left">N-Bitfield(2,9)</td>
 <td style="text-align:left">Two bits for each Data Activity:<p><code>0</code> Not Applicable. SensitiveDataLimitUseNotice value was not applicable or no notice was provided.<p><code>1</code> Opted Out<p><code>2</code> Did Not Opt Out<p> Data Activities: <p>(1) Opt-Out of the Use or Disclosure of the Consumer&#39;s Sensitive Personal Information Which Reveals a Consumer&#39;s Social Security, Driver&#39;s License, State Identification Card, or Passport Number.<p>(2) Opt-Out of the Use or Disclosure of the Consumer&#39;s Sensitive Personal Information Which Reveals a Consumer&#39;s Account Log-In, Financial Account, Debit Card, or Credit Card Number in Combination with Any Required Security or Access Code, Password, or Credentials Allowing Access to an Account.<p>(3) Opt-Out of the Use or Disclosure of the Consumer&#39;s Sensitive Personal Information Which Reveals a Consumer&#39;s Precise Geolocation.<p>(4) Opt-Out of the Use or Disclosure of the Consumer&#39;s Sensitive Personal Information Which Reveals a Consumer&#39;s Racial or Ethnic Origin, Religious or Philosophical Beliefs, or Union Membership.<p>(5) Opt-Out of the Use or Disclosure of the Consumer&#39;s Sensitive Personal Information Which Reveals the contents of a Consumer&#39;s Mail, Email, and Text Messages unless You Are the Intended Recipient of the Communication.<p>(6) Opt-Out of the Use or Disclosure of the Consumer&#39;s Sensitive Personal Information Which Reveals a Consumer&#39;s Genetic Data.<p>(7) Opt-Out of the Use or Disclosure of the Consumer&#39;s Sensitive Personal Information Consisting of Biometric Information tor the Purpose of Uniquely Identifying a Consumer.<p>(8) Opt-Out of the Use or Disclosure of the Consumer&#39;s Sensitive Personal Information Consisting of Personal Information Collected and Analyzed Concerning a Consumer&#39;s Health.<p>(9) Opt-Out of the Use or Disclosure of the Consumer&#39;s Sensitive Personal Information Consisting of Personal Information Collected and Analyzed Concerning a Consumer&#39;s Sex Life or Sexual Orientation.</td>
 </tr>
 <tr>
-<td style="text-align:left">KnownChildSensitiveDataConsents</td>
+<td style="text-align:left"><code>KnownChildSensitiveDataConsents</code></td>
 <td style="text-align:left">N-Bitfield(2,2)</td>
 <td style="text-align:left">Two bits for each Data Activity:<p><code>0</code> Not Applicable. The Business does not have actual knowledge that it Processes Personal Information of Consumers Less Than 16 years of Age.<p><code>1</code> No Consent<p><code>2</code> Consent<p>Data Activities:<p>(1) Consent to Sell the Personal Information of Consumers Less Than 16 years of Age<p>(2) Consent to Share the Personal Information of Consumers Less Than 16 years of Age</td>
 </tr>
 <tr>
-<td style="text-align:left">PersonalDataConsents</td>
+<td style="text-align:left"><code>PersonalDataConsents</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Consent to Collection, Use, Retention, Sale, and/or Sharing of the Consumer&#39;s Personal Data that Is Unrelated to or Incompatible with the Purpose(s) for which the Consumer&#39;s Personal Data Was Collected or Processed<p><code>0</code> Not Applicable. The Business does not use, retain, Sell, or Share the Consumer&#39;s Personal Data for advertising purposes that are unrelated to or incompatible with the purpose(s) for which the Consumer&#39;s Personal Data was collected or processed.<p><code>1</code> No Consent<p><code>2</code> Consent</td>
 </tr>
 <tr>
-<td style="text-align:left">MspaCoveredTransaction</td>
+<td style="text-align:left"><code>MspaCoveredTransaction<code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Publisher or Advertiser, as applicable, is a signatory to the IAB Multistate Service Provider Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a &quot;Covered Transaction&quot; as defined in the MSPA.<p><code>1</code> Yes<p><code>2</code> No</td>
+<td style="text-align:left"><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
+<p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multistate Service Provider Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a &quot;Covered Transaction&quot; as defined in the MSPA.<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 <tr>
-<td style="text-align:left">MspaOptOutOptionMode</td>
+<td style="text-align:left"><code>MspaOptOutOptionMode</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Publisher or Advertiser, as applicable, has enabled &quot;Opt-Out Option Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
+<td style="text-align:left"><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled &quot;Opt-Out Option Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 <tr>
-<td style="text-align:left">MspaServiceProviderMode</td>
+<td style="text-align:left"><code>MspaServiceProviderMode</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Publisher or Advertiser, as applicable, has enabled &quot;Service Provider Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
+<td style="text-align:left"><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled &quot;Service Provider Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 </tbody>
 </table>
 
 
-<h4 id="gpc-subsection">GPC Sub-section</h4>
-<p><a href="https://globalprivacycontrol.github.io/gpc-spec/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this sub-section.</p>
+<h4 id="gpc-subsection">GPC Subsection</h4>
+<p><a href="https://w3c.github.io/gpc/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this subsection.</p>
 
 <table>
 <thead>
@@ -139,12 +146,12 @@
 </thead>
 <tbody>
 <tr>
-<td style="text-align:left">SubsectionType</td>
+<td style="text-align:left"><code>SubsectionType</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left"><p><code>0</code> Core<p><code>1</code> GPC</td>
+<td style="text-align:left"><p><code>1</code> GPC</td>
 </tr>
 <tr>
-<td style="text-align:left">Gpc</td>
+<td style="text-align:left"><code>Gpc<code></td>
 <td style="text-align:left">Boolean</td>
 <td style="text-align:left"><p><code>0</code> false<p><code>1</code> true</td>
 </tr>

--- a/Sections/US-States/CA/README.md
+++ b/Sections/US-States/CA/README.md
@@ -2,4 +2,4 @@
 
 
  
-Contained in this directory are technical specifications for California privacy strings to support CPRA compliance. 
+Contained in this directory are technical specifications for California privacy strings to support CCPA/CPRA compliance. 

--- a/Sections/US-States/CO/GPP Extension: Colorado Privacy Technical Specification.md
+++ b/Sections/US-States/CO/GPP Extension: Colorado Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-colorado-privacy-technical-specification">GPP Extension: Colorado Privacy Technical Specification</h1>
+<h1 id="gpp-extension-colorado-privacy-technical-specification">Colorado Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Colorado section of the GPP specification by those who (i) are Signatories to IAB Privacy, Inc.’s <a href=https://www.iabprivacy.com/>Multi-State Privacy Agreement (MSPA)</a>; and (ii) those who are not signatories of the MSPA.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Colorado section of the GPP specification.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>
@@ -12,6 +12,10 @@
 <td><strong>Comments</strong></td>
 </tr>
 <tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr><tr>
 <td>December 2022</td>
 <td>1.0</td>
 <td>Version 1.0 released</td>
@@ -47,8 +51,8 @@
 </table>
 <h3 id="section-encoding">Section encoding</h3>
 <p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
-<h4 id="core-segment">Core Segment</h4>
-<p>The core segment must always be present. Where terms are capitalized in the ‘description’ field they are defined terms in Colo. Rev. Stat. 6-1-1303. It consists of the following fields:</p>
+<h4 id="core-segment">Core Subsection</h4>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined terms in Colo. Rev. Stat. 6-1-1303. It consists of the following fields:</p>
 <table>
 <thead>
 <tr>
@@ -59,65 +63,68 @@
 </thead>
 <tbody>
 <tr>
-<td style="text-align:left">Version</td>
+<td style="text-align:left"><code>Version</code></td>
 <td style="text-align:left">Int(6)</td>
 <td style="text-align:left">The version of this section specification used to encode the string.</td>
 </tr>
 <tr>
-<td style="text-align:left">SharingNotice</td>
+<td style="text-align:left"><code>SharingNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Sharing of Personal Data with Third Parties.<p><code>0</code> Not Applicable. The Controller does not share Personal Data with Third Parties.<p><code>1</code> Yes, notice was provided<p><code>2</code> No, notice was not provided</td>
 </tr>
 <tr>
-<td style="text-align:left">SaleOptOutNotice</td>
+<td style="text-align:left"><code>SaleOptOutNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Opportunity to Opt Out of the Sale of the Consumer&#39;s Personal Data<p><code>0</code> Not Applicable. The Controller does not Sell Personal Data.<p><code>1</code> Yes, notice was provided<p><code>2</code> No, notice was not provided</td>
 </tr>
 <tr>
-<td style="text-align:left">TargetedAdvertisingOptOutNotice</td>
+<td style="text-align:left"><code>TargetedAdvertisingOptOutNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Opportunity to Opt Out of Processing of the Consumer&#39;s Personal Data for Targeted Advertising<p><code>0</code> Not Applicable.The Controller does not Process Personal Data for Targeted Advertising.<p><code>1</code> Yes, notice was provided<p><code>2</code> No, notice was not provided</td>
 </tr>
 <tr>
-<td style="text-align:left">SaleOptOut</td>
+<td style="text-align:left"><code>SaleOptOut</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Opt-Out of the Sale of the Consumer&#39;s Personal Data<p><code>0</code> Not Applicable. SaleOptOutNotice value was not applicable or no notice was provided<p><code>1</code> Opted Out<p><code>2</code> Did Not Opt Out</td>
 </tr>
 <tr>
-<td style="text-align:left">TargetedAdvertisingOptOut</td>
+<td style="text-align:left"><code>TargetedAdvertisingOptOut</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Opt-Out of Processing the Consumer&#39;s Personal Data for Targeted Advertising<p><code>0</code> Not Applicable. TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided<p><code>1</code> Opted Out<p><code>2</code> Did Not Opt Out</td>
 </tr>
 <tr>
-<td style="text-align:left">SensitiveDataProcessing</td>
+<td style="text-align:left"><code>SensitiveDataProcessing</code></td>
 <td style="text-align:left">N-Bitfield(2,7)</td>
 <td style="text-align:left">Two bits for each Data Activity:<p><code>0</code> Not Applicable. The Controller does not Process the specific category of Sensitive Data.<p><code>1</code> No Consent<p><code>2</code> Consent<p>(1) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.<p>(2) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.<p>(3) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Condition or Diagnosis.<p>(4) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Sex Life or Sexual Orientation.<p>(5) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Citizenship or Citizenship Status.<p>(6) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Genetic Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.<p>(7) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Biometric Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.</td>
 </tr>
 <tr>
-<td style="text-align:left">KnownChildSensitiveDataConsents</td>
+<td style="text-align:left"><code>KnownChildSensitiveDataConsents</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Consent to Process Sensitive Data from a Known Child.<p><code>0</code> Not Applicable. The Controller does not Process Sensitive Data of a known Child.<p><code>1</code> No Consent<p><code>2</code> Consent</td>
 </tr>
 <tr>
-<td style="text-align:left">MspaCoveredTransaction</td>
+<td style="text-align:left"><code>MspaCoveredTransaction</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Publisher or Advertiser, as applicable, is a signatory to the IAB Multistate Service Provider Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a &quot;Covered Transaction&quot; as defined in the MSPA.<p><code>1</code> Yes<p><code>2</code> No</td>
+<td style="text-align:left"><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
+<p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multistate Service Provider Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a &quot;Covered Transaction&quot; as defined in the MSPA.<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 <tr>
-<td style="text-align:left">MspaOptOutOptionMode</td>
+<td style="text-align:left"><code>MspaOptOutOptionMode</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Publisher or Advertiser, as applicable, has enabled &quot;Opt-Out Option Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
+<td style="text-align:left"><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled &quot;Opt-Out Option Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 <tr>
-<td style="text-align:left">MspaServiceProviderMode</td>
+<td style="text-align:left"><code>MspaServiceProviderMode</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Publisher or Advertiser, as applicable, has enabled &quot;Service Provider Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
+<td style="text-align:left"><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled &quot;Service Provider Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 </tbody>
 </table>
 
-<h4 id="gpc-subsection">GPC Sub-section</h4>
-<p><a href="https://globalprivacycontrol.github.io/gpc-spec/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this sub-section.</p>
+<h4 id="gpc-subsection">GPC Subsection</h4>
+<p><a href="https://w3c.github.io/gpc/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this subsection.</p>
 
 <table>
 <thead>
@@ -129,12 +136,12 @@
 </thead>
 <tbody>
 <tr>
-<td style="text-align:left">SubsectionType</td>
+<td style="text-align:left"><code>SubsectionType</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left"><p><code>0</code> Core<p><code>1</code> GPC</td>
+<td style="text-align:left"><code>1</code> GPC</td>
 </tr>
 <tr>
-<td style="text-align:left">Gpc</td>
+<td style="text-align:left"><code>Gpc</code></td>
 <td style="text-align:left">Boolean</td>
 <td style="text-align:left"><p><code>0</code> false<p><code>1</code> true</td>
 </tr>

--- a/Sections/US-States/CT/GPP Extension: Connecticut Privacy Technical Specification.md
+++ b/Sections/US-States/CT/GPP Extension: Connecticut Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-connecticut-privacy-technical-specification">GPP Extension: Connecticut Privacy Technical Specification</h1>
+<h1 id="gpp-extension-connecticut-privacy-technical-specification">Connecticut Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Connecticut section of the GPP specification by those who (i) are Signatories to IAB Privacy, Inc.’s <a href=https://www.iabprivacy.com/>Multi-State Privacy Agreement (MSPA)</a>; and (ii) those who are not signatories of the MSPA.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Connecticut section of the GPP specification.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>
@@ -10,6 +10,11 @@
 <td><strong>Date</strong></td>
 <td><strong>Version</strong></td>
 <td><strong>Comments</strong></td>
+</tr>
+<tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
 </tr>
 <tr>
 <td>December 2022</td>
@@ -47,8 +52,8 @@
 </table>
 <h3 id="section-encoding">Section encoding</h3>
 <p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
-<h4 id="core-segment">Core Segment</h4>
-<p>The core segment must always be present. Where terms are capitalized in the ‘description’ field they are defined terms in Conn. PA No. 22-15, Sec. 1 [Pending codification]. It consists of the following fields:</p>
+<h4 id="core-segment">Core Subsection</h4>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined terms in Conn. PA No. 22-15, Sec. 1. It consists of the following fields:</p>
 <table>
 <thead>
 <tr>
@@ -59,65 +64,68 @@
 </thead>
 <tbody>
 <tr>
-<td style="text-align:left">Version</td>
+<td style="text-align:left"><code>Version</code></td>
 <td style="text-align:left">Int(6)</td>
 <td style="text-align:left">The version of this section specification used to encode the string.</td>
 </tr>
 <tr>
-<td style="text-align:left">SharingNotice</td>
+<td style="text-align:left"><code>SharingNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Sharing of Personal Data with Third Parties<p><code>0</code> Not Applicable. The Controller does not share Personal Data with Third Parties.<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 <tr>
-<td style="text-align:left">SaleOptOutNotice</td>
+<td style="text-align:left"><code>SaleOptOutNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Opportunity to Opt Out of the Sale of the Consumer&#39;s Personal Data<p><code>0</code> Not Applicable. The Controller does not Sell Personal Data.<p><code>1</code> Yes, notice was provided<p><code>2</code> No, notice was not provided</td>
 </tr>
 <tr>
-<td style="text-align:left">TargetedAdvertisingOptOutNotice</td>
+<td style="text-align:left"><code>TargetedAdvertisingOptOutNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Opportunity to Opt Out of Processing of the Consumer&#39;s Personal Data for Targeted Advertising<p><code>0</code> Not Applicable.The Controller does not Process Personal Data for Targeted Advertising.<p><code>1</code> Yes, notice was provided<p><code>2</code> No, notice was not provided</td>
 </tr>
 <tr>
-<td style="text-align:left">SaleOptOut</td>
+<td style="text-align:left"><code>SaleOptOut</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Opt-Out of the Sale of the Consumer&#39;s Personal Data<p><code>0</code> Not Applicable. SaleOptOutNotice value was not applicable or no notice was provided<p><code>1</code> Opted Out<p><code>2</code> Did Not Opt Out</td>
 </tr>
 <tr>
-<td style="text-align:left">TargetedAdvertisingOptOut</td>
+<td style="text-align:left"><code>TargetedAdvertisingOptOut</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Opt-Out of Processing the Consumer&#39;s Personal Data for Targeted Advertising<p><code>0</code> Not Applicable. TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided<p><code>1</code> Opted Out<p><code>2</code> Did Not Opt Out</td>
 </tr>
 <tr>
-<td style="text-align:left">SensitiveDataProcessing</td>
+<td style="text-align:left"><code>SensitiveDataProcessing</code></td>
 <td style="text-align:left">N-Bitfield(2,8)</td>
 <td style="text-align:left">Two bits for each Data Activity:<p><code>0</code> Not Applicable. The Controller does not Process the specific category of Sensitive Data.<p><code>1</code> No Consent<p><code>2</code> Consent<p>(1) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.<p>(2) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.<p>(3) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Condition or Diagnosis.<p>(4) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Sex Life or Sexual Orientation.<p>(5) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.<p>(6) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Genetic Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.<p>(7) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Biometric Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.<p>(8) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Precise Geolocation Data.</td>
 </tr>
 <tr>
-<td style="text-align:left">KnownChildSensitiveDataConsents</td>
+<td style="text-align:left"><code>KnownChildSensitiveDataConsents</code></td>
 <td style="text-align:left">N-Bitfield(2,3)</td>
 <td style="text-align:left">Two bits for each Data Activity:<p><code>0</code> Not Applicable. The Controller does not Process Sensitive Data of a known Child.<p><code>1</code> No Consent<p><code>2</code> Consent<p>(1) Consent to Process Sensitive Data from a Known Child.<p>(2) Consent to Sell the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age.<p>(3) Consent to Process the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age for Purposes of Targeted Advertising.</td>
 </tr>
 <tr>
-<td style="text-align:left">MspaCoveredTransaction</td>
+<td style="text-align:left"><code>MspaCoveredTransaction</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Publisher or Advertiser, as applicable, is a signatory to the IAB Multistate Service Provider Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a &quot;Covered Transaction&quot; as defined in the MSPA.<p><code>1</code> Yes<p><code>2</code> No</td>
+<td style="text-align:left"><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
+<p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multistate Service Provider Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a &quot;Covered Transaction&quot; as defined in the MSPA.<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 <tr>
-<td style="text-align:left">MspaOptOutOptionMode</td>
+<td style="text-align:left"><code>MspaOptOutOptionMode</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Publisher or Advertiser, as applicable, has enabled &quot;Opt-Out Option Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
+<td style="text-align:left"><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>20/code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled &quot;Opt-Out Option Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 <tr>
-<td style="text-align:left">MspaServiceProviderMode</td>
+<td style="text-align:left"><code>MspaServiceProviderMode</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Publisher or Advertiser, as applicable, has enabled &quot;Service Provider Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
+<td style="text-align:left"><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled &quot;Service Provider Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 </tbody>
 </table>
 
-<h4 id="gpc-subsection">GPC Sub-section</h4>
-<p><a href="https://globalprivacycontrol.github.io/gpc-spec/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this sub-section.</p>
+<h4 id="gpc-subsection">GPC Subsection</h4>
+<p><a href="https://w3c.github.io/gpc/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this subsection.</p>
 
 <table>
 <thead>
@@ -129,12 +137,12 @@
 </thead>
 <tbody>
 <tr>
-<td style="text-align:left">SubsectionType</td>
+<td style="text-align:left"><code>SubsectionType</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left"><p><code>0</code> Core<p><code>1</code> GPC</td>
+<td style="text-align:left"><code>1</code> GPC</td>
 </tr>
 <tr>
-<td style="text-align:left">Gpc</td>
+<td style="text-align:left"><code>Gpc</code></td>
 <td style="text-align:left">Boolean</td>
 <td style="text-align:left"><p><code>0</code> false<p><code>1</code> true</td>
 </tr>

--- a/Sections/US-States/DE/GPP Extension: IAB Privacy’s Delaware Privacy Technical Specification.md
+++ b/Sections/US-States/DE/GPP Extension: IAB Privacy’s Delaware Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-iab-privacy-s-delaware-privacy-technical-specification">GPP Extension: IAB Privacy’s Delaware Privacy Technical Specification</h1>
+<h1 id="gpp-extension-iab-privacy-s-delaware-privacy-technical-specification">Delaware Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Delaware section of the GPP specifications in accordance with the IAB Privacy Multi-State Privacy Agreement legal requirements, applicable to both Signatories and non-Signatories of the MSPA.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Delaware section of the GPP specifications.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>
@@ -11,7 +11,11 @@
 <td><strong>Version</strong></td>
 <td><strong>Comments</strong></td>
 </tr>
-
+<tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr>
 <tr>
 <td>July 2024</td>
 <td>1.0</td>
@@ -53,8 +57,8 @@
 </div>
 <h3>Section encoding</h3>
 <p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
-<h4>Core Segment</h4>
-<p>The core sub-section must always be present. Where terms are capitalized in the ‘description’ field they are defined in Del. Code Ann. tit. 6, § 12D-102. It consists of the following fields:</p>
+<h4>Core Subsection</h4>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined in Del. Code Ann. tit. 6, § 12D-102. It consists of the following fields:</p>
 <div>
   <table>
     <thead>
@@ -72,141 +76,120 @@
     </thead>
     <tbody>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Version</span>
-        </td>
+        <td><code>Version</code></td>
         <td>Int(6)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">The version of this section specification used to encode the string.</span>
-        </td>
+        <td>The version of this section specification used to encode the string.</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">ProcessingNotice</span>
-        </td>
+        <td><code>ProcessingNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Processing of Personal Data.</span>
-          <p></p><code>0</code> = Not Applicable, <span style="color:rgb(36, 41, 47);">The Controller does not Process Personal Data</span><p></p><code>1</code> = Yes, notice was provided <p></p><code>2</code> = No, notice was not provided</td>
+        <td>Notice of the Processing of Personal Data.
+          <p></p><code>0</code> = Not Applicable, The Controller does not Process Personal Data
+          <p></p><code>1</code> = Yes, notice was provided <p></p><code>2</code> = No, notice was not provided</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOutNotice</span>
-        </td>
+        <td><code>SaleOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data&nbsp;</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">,
-          </span>The
-          <span style="color:rgb(36, 41, 47);">Controller does not Sell Personal Data</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data&nbsp;><p></p><code>0</code> = Not Applicable, The Controller does not Sell Personal Data
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOutNotice</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">, the Controller does not Process Personal Data for Targeted Advertising</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising<p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data for Targeted Advertising
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOut</span>
-        </td>
+        <td><code>SaleOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of the Sale of the Consumer’s Personal Data</span><p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out <p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out 
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOut</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SensitiveDataProcessing</span>
-        </td>
+        <td><code>SensitiveDataProcessing</code></td>
         <td>N-Bitfield(2,9)</td>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data<p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(2). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Condition or Diagnosis (Including Pregnancy).</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(4). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sex Life or Sexual Orientation.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(5). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(6). Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(7). Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(8). Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(9). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Status as Transgender or Nonbinary.</span><p></p>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent&nbsp;
+        <p></p>(1) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.<p></p>
+          (2) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.<p></p>
+          (3) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Condition or Diagnosis (Including Pregnancy).<p></p>
+          (4) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sex Life or Sexual Orientation.<p></p>
+          (5) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.<p></p>
+          (6) Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data.<p></p>
+          (7) Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data.<p></p>
+          (8) Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.<p></p>
+          (9) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Status as Transgender or Nonbinary.<p></p>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">KnownChildSensitiveDataConsents</span>
-        </td>
+        <td><code>KnownChildSensitiveDataConsents</code></td>
         <td>N-Bitfield(2,5)</td>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not
-          <span style="color:rgb(36, 41, 47);">Process Sensitive Data of a known Child</span><p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Consent to Process Sensitive Data from a Known Child.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(2). Consent to Sell the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Consent to Process the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age for Purposes of Targeted Advertising.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(4). Consent to Sell the Personal Data of Consumers At Least 16 Years of Age but Younger Than 18 Years of Age.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(5). Consent to Process the Personal Data of Consumers At Least 16 Years of Age but Younger Than 18 Years of Age for Purposes of Targeted Advertising.</span><p></p>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Sensitive Data of a known Child
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent&nbsp;
+        <p></p>(1) Consent to Process Sensitive Data from a Known Child.<p></p>
+          (2) Consent to Sell the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age.<p></p>
+          (3) Consent to Process the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age for Purposes of Targeted Advertising.<p></p>
+          (4) Consent to Sell the Personal Data of Consumers At Least 16 Years of Age but Younger Than 18 Years of Age.<p></p>
+          (5) Consent to Process the Personal Data of Consumers At Least 16 Years of Age but Younger Than 18 Years of Age for Purposes of Targeted Advertising.<p></p>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">AdditionalDataProcessingConsent</span>
-        </td>
+        <td><code>AdditionalDataProcessingConsent</code></td>
         <td>Int(2)</td>
-        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed0 = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)<p></p><code>1</code> = No Consent <p></p><code>2</code> = Consent&nbsp;</td>
+        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed0 = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)
+        <p></p><code>1</code> = No Consent 
+        <p></p><code>2</code> = Consent</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaCoveredTransaction</span>
-        </td>
+        <td><code>MspaCoveredTransaction</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.&nbsp;</span><p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
+<p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaOptOutOptionMode</span>
-        </td>
+        <td><code>MspaOptOutOptionMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaServiceProviderMode</span>
-        </td>
+        <td><code>MspaServiceProviderMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>0</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>0</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
     </tbody>
   </table>
 </div>
-<h4>GPC Sub-section</h4>
-<p>
-  <a target="_blank" href="https://globalprivacycontrol.github.io/gpc-spec/">
-    <span style="color:rgb(17, 85, 204);">GPC</span>
-  </a>
-  <span style="color:rgb(36, 41, 47);">
-    is signaled in user agent headers
-  </span>
-  <span style="color:rgb(36, 41, 47);">(Sec-GPC)</span>
-  <span style="color:rgb(36, 41, 47);">
-    and a simple javascript API
-  </span>
-  <span style="color:rgb(36, 41, 47);">(globalPrivacyControl)</span>
-  <span style="color:rgb(36, 41, 47);">. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this sub-section.</span>
-</p>
+<h4>GPC Subsection</h4>
+<p><a href="https://w3c.github.io/gpc/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this subsection.</p>
+
 <div>
   <table>
     <tbody>
@@ -222,12 +205,12 @@
         </td>
       </tr>
       <tr>
-        <td>SubsectionType</td>
+        <td><code>SubsectionType</code></td>
         <td>Int(2)</td>
-        <td><p></p><code>0</code> = Core<p></p><code>1</code> = GPC</td>
+        <td><code>1</code> = GPC</td>
       </tr>
       <tr>
-        <td>Gpc</td>
+        <td><code>Gpc</code></td>
         <td>Boolean</td>
         <td><p></p><code>0</code> = false<p></p><code>1</code> = true</td>
       </tr>

--- a/Sections/US-States/DE/README.md
+++ b/Sections/US-States/DE/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s Delaware Privacy Technical Specification
+# Delaware Privacy Technical Specification
 
 
  

--- a/Sections/US-States/FL/GPP Extension: IAB Privacy’s Florida Privacy Technical Specification.md
+++ b/Sections/US-States/FL/GPP Extension: IAB Privacy’s Florida Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-iab-privacy-s-florida-privacy-technical-specification">GPP Extension: IAB Privacy’s Florida Privacy Technical Specification</h1>
+<h1 id="gpp-extension-iab-privacy-s-florida-privacy-technical-specification">Florida Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Florida section of the GPP specifications in accordance with the IAB Privacy Multi-State Privacy Agreement legal requirements, applicable to both Signatories and non-Signatories of the MSPA.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>
@@ -11,7 +11,11 @@
 <td><strong>Version</strong></td>
 <td><strong>Comments</strong></td>
 </tr>
-
+<tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr>
 <tr>
 <td>May 2024</td>
 <td>1.0</td>
@@ -53,8 +57,8 @@
 </div>
 <h3>Section encoding</h3>
 <p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
-<h4>Core Segment</h4>
-<p>The core sub-section must always be present. Where terms are capitalized in the ‘description’ field they are defined terms in Fla. Stat. § 501.702. It consists of the following fields:</p>
+<h4>Core Subsection</h4>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined terms in Fla. Stat. § 501.702. It consists of the following fields:</p>
 <div>
   <table>
     <thead>
@@ -72,119 +76,114 @@
     </thead>
     <tbody>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Version</span>
-        </td>
+        <td><code>Version</code></td>
         <td>Int(6)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">The version of this section specification used to encode the string.</span>
-        </td>
+        <td>The version of this section specification used to encode the string. </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">ProcessingNotice</span>
-        </td>
+        <td><code>ProcessingNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Processing of Personal Data.</span><p></p><code>0</code> = Not Applicable,
-          <span style="color:rgb(36, 41, 47);">The Controller does not Process Personal Data</span><p></p><code>1</code> = Yes, notice was provided<p></p><code>2</code> = No, notice was not provided</td>
+        <td>Notice of the Processing of Personal Data.
+        <p></p><code>0</code> = Not Applicable, The Controller does not Process Personal Data
+        <p></p><code>1</code> = Yes, notice was provided
+        <p></p><code>2</code> = No, notice was not provided</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOutNotice</span>
-        </td>
+        <td><code>SaleOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data&nbsp;</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">,
-          </span>The
-          <span style="color:rgb(36, 41, 47);">Controller does not Sell Personal Data</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable, The Controller does not Sell Personal Data
+        <p></p><code>1</code> = Yes, notice was provided
+        <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOutNotice</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">, the Controller does not Process Personal Data for Targeted Advertising</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data for Targeted Advertising
+        <p></p><code>1</code> = Yes, notice was provided
+        <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOut</span>
-        </td>
+        <td><code>SaleOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of the Sale of the Consumer’s Personal Data</span><p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOut</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SensitiveDataProcessing</span>
-        </td>
+        <td><code>SensitiveDataProcessing</code></td>
         <td>N-Bitfield(2,8)</td>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data<p></p><code>1</code> = No Consent <p></p><code>2</code> = Consent&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(2). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Diagnosis.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(4). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sexual Orientation.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(5). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(6). Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(7). Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(8). Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.</span>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data
+        <p></p><code>1</code> = No Consent 
+        <p></p><code>2</code> = Consent
+        <p></p>(1) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.<p></p>
+          (2) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.<p></p>
+          (3) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Diagnosis.<p></p>
+          (4) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sexual Orientation.<p></p>
+          (5) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.<p></p>
+          (6) Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (7) Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (8) Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">KnownChildSensitiveDataConsents</span>
-        </td>
+        <td><code>KnownChildSensitiveDataConsents</code></td>
         <td>N-Bitfield(2,3)</td>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not
-          <span style="color:rgb(36, 41, 47);">Process Sensitive Data of a known Child</span><p></p><code>1</code> = No Consent <p></p><code>2</code> = Consent&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Consent to Process Sensitive Data from a Known Child Under the Age of 13.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(2). Consent to Process Sensitive Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Consent to Process the Sensitive Data of Consumers At Least 16 Years of Age but Younger Than 18 Years of Age.</span><p></p>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Sensitive Data of a known Child
+        <p></p><code>1</code> = No Consent 
+        <p></p><code>2</code> = Consent
+        ><p></p>(1) Consent to Process Sensitive Data from a Known Child Under the Age of 13.
+        <p></p>(2) Consent to Process Sensitive Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age.
+        <p></p>(3) Consent to Process the Sensitive Data of Consumers At Least 16 Years of Age but Younger Than 18 Years of Age.<p></p>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">AdditionalDataProcessingConsent</span>
-        </td>
+        <td><code>AdditionalDataProcessingConsent</code></td>
         <td>Int(2)</td>
-        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed<p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)<p></p><code>1</code> = No Consent <p></p><code>2</code> = Consent&nbsp;</td>
+        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)
+        <p></p><code>1</code> = No Consent 
+        <p></p><code>2</code> = Consent</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaCoveredTransaction</span>
-        </td>
+        <td><code>MspaCoveredTransaction</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.&nbsp;</span><p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
+<p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaOptOutOptionMode</span>
-        </td>
+        <td><code>MspaOptOutOptionMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaServiceProviderMode</span>
-        </td>
+        <td><code>MspaServiceProviderMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
     </tbody>
   </table>

--- a/Sections/US-States/FL/README.md
+++ b/Sections/US-States/FL/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s Florida Privacy Technical Specification
+# Florida Privacy Technical Specification
 
 
  

--- a/Sections/US-States/IA/GPP Extension: IAB Privacy’s Iowa Privacy Technical Specification.md
+++ b/Sections/US-States/IA/GPP Extension: IAB Privacy’s Iowa Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-iab-privacy-s-iowa-privacy-technical-specification">GPP Extension: IAB Privacy’s Iowa Privacy Technical Specification</h1>
+<h1 id="gpp-extension-iab-privacy-s-iowa-privacy-technical-specification">Iowa Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Iowa section of the GPP specifications in accordance with the IAB Privacy Multi-State Privacy Agreement legal requirements, applicable to both Signatories and non-Signatories of the MSPA.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Iowa section of the GPP specifications.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>
@@ -11,7 +11,11 @@
 <td><strong>Version</strong></td>
 <td><strong>Comments</strong></td>
 </tr>
-
+<tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr>
 <tr>
 <td>July 2024</td>
 <td>1.0</td>
@@ -53,8 +57,8 @@
 </div>
 <h3>Section encoding</h3>
 <p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
-<h4>Core Segment</h4>
-<p>The core sub-section must always be present. Where terms are capitalized in the ‘description’ field they are defined in the Iowa Act Relating to Consumer Data Protection, Iowa Code § 715D.1. It consists of the following fields:</p>
+<h4>Core Subsection</h4>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined in the Iowa Act Relating to Consumer Data Protection, Iowa Code § 715D.1. It consists of the following fields:</p>
 <div>
   <table>
     <thead>
@@ -72,140 +76,115 @@
     </thead>
     <tbody>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Version</span>
-        </td>
+        <td><code>Version</code></td>
         <td>Int(6)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">The version of this section specification used to encode the string.</span>
-        </td>
+        <td>The version of this section specification used to encode the string.</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">ProcessingNotice</span>
-        </td>
+        <td><code>ProcessingNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Processing of Personal Data.</span><p></p><code>0</code> = Not Applicable,
-          <span style="color:rgb(36, 41, 47);">the Controller does not Process Personal Data</span><p></p><code>1</code> = Yes, notice was provided<p></p><code>2</code> = No, notice was not provided</td>
+        <td>Notice of the Processing of Personal Data.
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data
+        <p></p><code>1</code> = Yes, notice was provided
+        <p></p><code>2</code> = No, notice was not provided</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOutNotice</span>
-        </td>
+        <td><code>SaleOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data&nbsp;</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">,
-          </span>the
-          <span style="color:rgb(36, 41, 47);">Controller does not Sell Personal Data</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable,the Controller does not Sell Personal Data
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOutNotice</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">, the Controller does not Process Personal Data for Targeted Advertising</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data for Targeted Advertising
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SensitiveDataOptOutNotice</span>
-        </td>
+        <td><code>SensitiveDataOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of the Processing of the Consumer’s Sensitive Data</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>0</code> = Not Applicable, the Controller does not Process Sensitive Data</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of the Processing of the Consumer’s Sensitive Data
+          <p></p><code>0</code> = Not Applicable, the Controller does not Process Sensitive Data
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOut</span>
-        </td>
+        <td><code>SaleOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of the Sale of the Consumer’s Personal Data</span><p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOut</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SensitiveDataProcessing</span>
-        </td>
+        <td><code>SensitiveDataProcessing</code></td>
         <td>N-Bitfield(2,8)</td>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(2). Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Diagnosis.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(4). Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sexual Orientation.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(5). Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Citizenship Status.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(6). Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Genetic Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(7). Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Biometric Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(8). Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.</span><p></p>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out&
+        <p></p>(1) Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.<p></p>
+          (2) Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.<p></p>
+          (3) Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Diagnosis.<p></p>
+          (4) Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sexual Orientation.<p></p>
+          (5) Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Citizenship Status.<p></p>
+          (6) Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Genetic Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (7) Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Biometric Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (8) Opt-Out of the Processing of the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.<p></p>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">KnownChildSensitiveDataConsents</span>
-        </td>
+        <td><code>KnownChildSensitiveDataConsents</code></td>
         <td>Int(2)</td>
-        <td>Consent to Process Sensitive Data from a Known Child<p></p><code>0</code> = Not Applicable, the Controller does not
-          <span style="color:rgb(36, 41, 47);">Process Sensitive Data of a known Child</span><p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;</td>
+        <td>Consent to Process Sensitive Data from a Known Child
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Sensitive Data of a known Child
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaCoveredTransaction</span>
-        </td>
+        <td><code>MspaCoveredTransaction</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.&nbsp;</span><p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
+<p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaOptOutOptionMode</span>
-        </td>
+        <td><code>MspaOptOutOptionMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaServiceProviderMode</span>
-        </td>
+        <td><code>>MspaServiceProviderMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
     </tbody>
   </table>
 </div>
-<h4>GPC Sub-section</h4>
-<p>
-  <a target="_blank" href="https://globalprivacycontrol.github.io/gpc-spec/">
-    <span style="color:rgb(17, 85, 204);">GPC</span>
-  </a>
-  <span style="color:rgb(36, 41, 47);">
-    is signaled in user agent headers
-  </span>
-  <span style="color:rgb(36, 41, 47);">(Sec-GPC)</span>
-  <span style="color:rgb(36, 41, 47);">
-    and a simple javascript API
-  </span>
-  <span style="color:rgb(36, 41, 47);">(globalPrivacyControl)</span>
-  <span style="color:rgb(36, 41, 47);">. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this sub-section.</span>
-</p>
+<h4>GPC Subsection</h4>
+<p><a href="https://w3c.github.io/gpc/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this subsection.</p>
 <div>
   <table>
     <tbody>
@@ -221,12 +200,12 @@
         </td>
       </tr>
       <tr>
-        <td>SubsectionType</td>
+        <td><code>SubsectionType<code></td>
         <td>Int(2)</td>
-        <td><p></p><code>0</code> = Core<p></p><code>1</code> = GPC</td>
+        <td><code>1</code> = GPC</td>
       </tr>
       <tr>
-        <td>Gpc</td>
+        <td><code>Gpc</code></td>
         <td>Boolean</td>
         <td><p></p><code>0</code> = false<p></p><code>1</code> = true</td>
       </tr>

--- a/Sections/US-States/IA/README.md
+++ b/Sections/US-States/IA/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s Iowa Privacy Technical Specification
+# Iowa Privacy Technical Specification
 
 
  

--- a/Sections/US-States/IN/Indiana Privacy Technical Specification.md
+++ b/Sections/US-States/IN/Indiana Privacy Technical Specification.md
@@ -11,6 +11,11 @@
     <td><strong>Comments</strong></td>
 </tr>
 <tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr>
+<tr>
 <td>April 2026</td>
     <td>1.0</td>
     <td>Updated SubSections field in Section header to never include Core subsection</td>
@@ -102,23 +107,24 @@
       <td><strong>Field Description</strong></td>
     </tr>
     <tr>
-      <td>MspaVersion</td>
+      <td><code>MspaVersion</code></td>
       <td>Int(6)</td>
-      <td><p>Version of the MSPA</p></td>
+      <td><p><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Version of the MSPA</p></td>
     </tr>
     <tr>
-      <td>MspaCoveredTransaction</td>
+      <td><code>MspaCoveredTransaction</code></td>
       <td>Int(2)</td>
-      <td>
+      <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
         <p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.</p>
         <p><code>1</code> = Yes</p>
         <p><code>2</code> = No</p>
       </td>
     </tr>
     <tr>
-      <td>MspaMode</td>
+      <td><code>MspaMode</code></td>
       <td>Int(2)</td>
-      <td>
+      <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
         <p>Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</p>
         <p>Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</p>
         <p><code>0</code> = Not Applicable</p>
@@ -127,7 +133,7 @@
       </td>
     </tr>
     <tr>
-      <td>ProcessingNotice</td>
+      <td><code>ProcessingNotice</code></td>
       <td>Int(2)</td>
       <td>
         <p>Notice Describing Processing of Personal Data.</p>
@@ -137,7 +143,7 @@
       </td>
     </tr>
     <tr>
-      <td>SaleOptOutNotice</td>
+      <td><code>SaleOptOutNotice</code></td>
       <td>Int(2)</td>
       <td>
         <p>Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data</p>
@@ -147,7 +153,7 @@
       </td>
     </tr>
     <tr>
-      <td>TargetedAdvertisingOptOutNotice</td>
+      <td><code>TargetedAdvertisingOptOutNotice</code></td>
       <td>Int(2)</td>
       <td>
         <p>Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising</p>
@@ -157,7 +163,7 @@
       </td>
     </tr>
     <tr>
-      <td>SaleOptOut</td>
+      <td><code>SaleOptOut</code></td>
       <td>Int(2)</td>
       <td>
         <p>Opt-Out of the Sale of the Consumer’s Personal Data</p>
@@ -167,7 +173,7 @@
       </td>
     </tr>
     <tr>
-      <td>TargetedAdvertisingOptOut</td>
+      <td><code>TargetedAdvertisingOptOut</code></td>
       <td>Int(2)</td>
       <td>
         <p>Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising</p>
@@ -177,7 +183,7 @@
       </td>
     </tr>
     <tr>
-      <td>KnownChildSensitiveDataConsents</td>
+      <td><code>KnownChildSensitiveDataConsents</code></td>
       <td>Int(2)</td>
       <td>
         <p>Consent to Process Personal Data concerning a known Child in accordance with COPPA as required by Ind. Code Ann. § 24-15-4-1(5)</p>
@@ -187,7 +193,7 @@
       </td>
     </tr>
     <tr>
-      <td>AdditionalDataProcessingConsent</td>
+      <td><code>AdditionalDataProcessingConsent</code></td>
       <td>Int(2)</td>
       <td>
         <p>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed</p>
@@ -207,7 +213,7 @@
       <td><strong>Field Description</strong></td>
     </tr>
     <tr>
-      <td>SensitiveDataProcessing</td>
+      <td><code>SensitiveDataProcessing<code></td>
       <td>N-Bitfield(2,8)</td>
       <td>
         <p>Consent from the Consumer to Process his or her Sensitive Data in accordance with Ind. Code Ann. § 24-15-4-1(5).</p>

--- a/Sections/US-States/IN/README.md
+++ b/Sections/US-States/IN/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s Indiana Privacy Technical Specification
+# Indiana Privacy Technical Specification
 
 
  

--- a/Sections/US-States/KY/Kentucky Privacy Technical Specification.md
+++ b/Sections/US-States/KY/Kentucky Privacy Technical Specification.md
@@ -11,6 +11,11 @@
     <td><strong>Comments</strong></td>
 </tr>
 <tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr>
+<tr>
 <td>April 2026</td>
     <td>1.0</td>
     <td>Updated SubSections field in Section header to never include Core subsection</td>
@@ -94,7 +99,7 @@
   </table>
 
   <h3>Core Subsection</h3>
-  <p>The core subsection must always be present. Where terms are capitalized in the ‘description’ field they are defined in Kentucky Act relating to consumer data privacy, HB 15 (2024). It consists of the following fields:</p>
+  <p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined in the Kentucky Act relating to consumer data privacy, HB 15 (2024). It consists of the following fields:</p>
   <table>
     <tr>
       <td><strong>Field name</strong></td>
@@ -102,23 +107,23 @@
       <td><strong>Field Description</strong></td>
     </tr>
     <tr>
-      <td>MspaVersion</td>
+      <td><code>MspaVersion</code></td>
       <td>Int(6)</td>
-      <td><p>Version of the MSPA</p></td>
+      <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b><p>Version of the MSPA</p></td>
     </tr>
     <tr>
-      <td>MspaCoveredTransaction</td>
+      <td><code>MspaCoveredTransaction</code></td>
       <td>Int(2)</td>
-      <td>
+      <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
         <p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.</p>
         <p><code>1</code> = Yes</p>
         <p><code>2</code> = No</p>
       </td>
     </tr>
     <tr>
-      <td>MspaMode</td>
+      <td><code>MspaMode</code></td>
       <td>Int(2)</td>
-      <td>
+      <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
         <p>Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</p>
         <p>Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</p>
         <p><code>0</code> = Not Applicable</p>
@@ -127,7 +132,7 @@
       </td>
     </tr>
     <tr>
-      <td>ProcessingNotice</td>
+      <td><code>ProcessingNotice</code></td>
       <td>Int(2)</td>
       <td>
         <p>Notice Describing Processing of Personal Data.</p>
@@ -137,7 +142,7 @@
       </td>
     </tr>
     <tr>
-      <td>SaleOptOutNotice</td>
+      <td><code>SaleOptOutNotice</code></td>
       <td>Int(2)</td>
       <td>
         <p>Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data</p>
@@ -147,7 +152,7 @@
       </td>
     </tr>
     <tr>
-      <td>TargetedAdvertisingOptOutNotice</td>
+      <td><code>TargetedAdvertisingOptOutNotice</code></td>
       <td>Int(2)</td>
       <td>
         <p>Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising</p>
@@ -157,7 +162,7 @@
       </td>
     </tr>
     <tr>
-      <td>SaleOptOut</td>
+      <td><code>SaleOptOut</code></td>
       <td>Int(2)</td>
       <td>
         <p>Opt-Out of the Sale of the Consumer’s Personal Data</p>
@@ -167,7 +172,7 @@
       </td>
     </tr>
     <tr>
-      <td>TargetedAdvertisingOptOut</td>
+      <td><code>TargetedAdvertisingOptOut</code></td>
       <td>Int(2)</td>
       <td>
         <p>Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising</p>
@@ -177,7 +182,7 @@
       </td>
     </tr>
     <tr>
-      <td>KnownChildSensitiveDataConsents</td>
+      <td><code>KnownChildSensitiveDataConsents</code></td>
       <td>Int(2)</td>
       <td>
         <p>Consent to process Personal Data concerning a known Child in accordance with COPPA as required by Kentucky Act, Sec. 4(1)(e).</p>
@@ -187,7 +192,7 @@
       </td>
     </tr>
     <tr>
-      <td>AdditionalDataProcessingConsent</td>
+      <td><code>AdditionalDataProcessingConsent</code></td>
       <td>Int(2)</td>
       <td>
         <p>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed</p>
@@ -207,7 +212,7 @@
       <td><strong>Field Description</strong></td>
     </tr>
     <tr>
-      <td>SensitiveDataProcessing</td>
+      <td><code>SensitiveDataProcessing</code></td>
       <td>N-Bitfield(2,8)</td>
       <td>
         <p>Consent from the Consumer to Process his or her Sensitive Data in accordance with Kentucky Act, Sec. 4(1)(e).</p>

--- a/Sections/US-States/KY/README.md
+++ b/Sections/US-States/KY/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s Kentucky Privacy Technical Specification
+# Kentucky Privacy Technical Specification
 
 
  

--- a/Sections/US-States/MD/Maryland Privacy Technical Specification.md
+++ b/Sections/US-States/MD/Maryland Privacy Technical Specification.md
@@ -11,6 +11,10 @@
     <td><strong>Comments</strong></td>
 </tr>
 <tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr><tr>
 <td>April 2026</td>
     <td>1.0</td>
     <td>Updated SubSections field in Section header to never include Core subsection</td>
@@ -62,17 +66,17 @@
     <td><strong>Description</strong></td>
 </tr>
 <tr>
-    <td>SectionID</td>
+    <td><code>SectionID<code></td>
     <td>Int(6)</td>
     <td>Section ID from the <a target="_blank" rel="noopener noreferrer nofollow" href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/Section%20Information.md">Section IDs</a> list</td>
 </tr>
 <tr>
-    <td>Version</td>
+    <td><code>Version<code></td>
     <td>Int(6)</td>
     <td>The version of this section specification used to encode the string</td>
 </tr>
 <tr>
-    <td>SubSections</td>
+    <td><code>SubSections<code></td>
     <td>Range (Fibonacci)</td>
     <td>List of subsection ids that are contained in this section. The IDs must be represented in the order the related subsections appear in the string. The Core subsection is required and always included first, so its ID (zero) is not included in the subsection IDs list.</td>
 </tr>
@@ -99,7 +103,7 @@
 </table>
 
 <h4>Core Subsection</h4>
-<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ field they are defined in Maryland Online Data Privacy Act of 2024. It consists of the following fields:</p>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined in Maryland Online Data Privacy Act of 2024. It consists of the following fields:</p>
 
 <table>
 <tbody>
@@ -109,23 +113,24 @@
     <td><strong>Description</strong></td>
 </tr>
 <tr>
-    <td>MspaVersion</td>
+    <td><code>MspaVersion</code></td>
     <td>Int(6)</td>
-    <td>Version of the MSPA</td>
+    <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+    <p>Version of the MSPA</td>
 </tr>
 <tr>
-    <td>MspaCoveredTransaction</td>
+    <td><code>MspaCoveredTransaction</code></td>
     <td>Int(2)</td>
-    <td>
+    <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
         <p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.</p>
         <p><code>1</code> = Yes</p>
         <p><code>2</code> = No</p>
       </td>
 </tr>
 <tr>
-    <td>MspaMode</td>
+    <td><code>MspaMode</code></td>
     <td>Int(2)</td>
-    <td>
+    <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code></code>.</b>
         <p>Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” or “Service Provider Mode” for the “Covered Transaction,” as defined in the MSPA.</p>
         <p><code>0</code> = Not Applicable</p>
         <p><code>1</code> = Opt-Out Option Mode</p>
@@ -133,7 +138,7 @@
     </td>
 </tr>
 <tr>
-    <td>ProcessingNotice</td>
+    <td><code>ProcessingNotice</code></td>
     <td>Int(2)</td>
     <td>
         <p>Notice describing processing of personal data. </p>
@@ -143,7 +148,7 @@
     </td>
 </tr>
 <tr>
-    <td>SaleOptOutNotice</td>
+    <td><code>SaleOptOutNotice</code></td>
     <td>Int(2)</td>
     <td>
         <p>Notice of the opportunity to opt out of the sale of the consumer’s personal data.</p>
@@ -153,7 +158,7 @@
     </td>
 </tr>
 <tr>
-    <td>TargetedAdvertisingOptOutNotice</td>
+    <td><code>TargetedAdvertisingOptOutNotice</code></td>
     <td>Int(2)</td>
     <td>
         <p>Notice of the opportunity to opt out of processing the consumer’s personal data for targeted advertising.</p>
@@ -163,7 +168,7 @@
     </td>
 </tr>
 <tr>
-    <td>SaleOptOut</td>
+    <td><code>SaleOptOut</code></td>
     <td>Int(2)</td>
     <td>
         <p>Opt-out of the sale of the consumer’s personal data.</p>
@@ -173,7 +178,7 @@
     </td>
 </tr>
 <tr>
-    <td>TargetedAdvertisingOptOut</td>
+    <td><code>TargetedAdvertisingOptOut</code></td>
     <td>Int(2)</td>
     <td>
         <p>Opt-out of processing the consumer’s personal data for targeted advertising.</p>
@@ -183,13 +188,13 @@
     </td>
 </tr>
 <tr>
-    <td>AdditionalDataProcessingConsent</td>
+    <td><code>AdditionalDataProcessingConsent</code></td>
     <td>Int(2)</td>
     <td>
         <p>Consent to processing of the consumer’s personal data that is not reasonably necessary for nor compatible with the disclosed purposes for which the consumer’s personal data was processed.</p>
         <p><code>0</code> = Not Applicable, the Controller does not Process Personal Data beyond disclosed purposes</p>
         <p><code>1</code> = No Consent</p>
-        <p><code>2</code> = Consent</p>>
+        <p><code>2</code> = Consent</p>
     </td>
 </tr>
 </tbody>
@@ -205,15 +210,14 @@
         <td><strong>Description</strong></td>
     </tr>
     <tr>
-        <td>SubsectionType</td>
+        <td><code>SubsectionType</code></td>
         <td>Int(2)</td>
         <td>
-           <p><code>0</code> = Core</p>
             <p><code>1</code> = GPC</p>
         </td>
     </tr>
     <tr>
-        <td>Gpc</td>
+        <td><code>Gpc</code></td>
         <td>Boolean</td>
         <td>
             <p><code>0</code> = false</p>

--- a/Sections/US-States/MD/README.md
+++ b/Sections/US-States/MD/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s Maryland Privacy Technical Specification
+# Maryland Privacy Technical Specification
 
 
  

--- a/Sections/US-States/MN/Minnesota Privacy Technical Specification.md
+++ b/Sections/US-States/MN/Minnesota Privacy Technical Specification.md
@@ -11,6 +11,11 @@
     <td><strong>Comments</strong></td>
 </tr>
 <tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr>
+<tr>
 <td>August 2025</td>
     <td>1.0</td>
     <td>Version 1.0 released</td>
@@ -54,12 +59,12 @@
         <td><strong>Description</strong></td>
     </tr>
     <tr>
-        <td>Version</td>
+        <td><code>Version</code></td>
         <td>Int(6)</td>
         <td>The version of this section specification used to encode the string.</td>
     </tr>
     <tr>
-        <td>ProcessingNotice</td>
+        <td><code>ProcessingNotice</code></td>
         <td>Int(2)</td>
         <td>
            <p>Notice Describing Processing of Personal Data</p>
@@ -69,7 +74,7 @@
         </td>
     </tr>
     <tr>
-        <td>SaleOptOutNotice</td>
+        <td><code>SaleOptOutNotice</code></td>
         <td>Int(2)</td>
         <td>
             <p>Notice of the Opportunity to Opt Out of the Sale of the Consumer's Personal Data</p>
@@ -79,7 +84,7 @@
         </td>
     </tr>
     <tr>
-        <td>TargetedAdvertisingOptOutNotice</td>
+        <td><code>TargetedAdvertisingOptOutNotice</code></td>
         <td>Int(2)</td>
         <td>
             <p>Notice of the Opportunity to Opt Out of Processing of the Consumer's Personal Data for Targeted Advertising</p>
@@ -89,7 +94,7 @@
         </td>
     </tr>
     <tr>
-        <td>SaleOptOut</td>
+        <td><code>SaleOptOut</code></td>
         <td>Int(2)</td>
         <td>
             <p>Opt-Out of the Sale of the Consumer's Personal Data</p>
@@ -99,7 +104,7 @@
         </td>
     </tr>
     <tr>
-        <td>TargetedAdvertisingOptOut</td>
+        <td><code>TargetedAdvertisingOptOut</code></td>
         <td>Int(2)</td>
         <td>
             <p>Opt-Out of Processing the Consumer's Personal Data for Targeted Advertising</p>
@@ -109,7 +114,7 @@
         </td>
     </tr>
     <tr>
-        <td>SensitiveDataProcessing</td>
+        <td><code>SensitiveDataProcessing</code></td>
         <td>N-Bitfield(2,8)</td>
         <td>
             <p>Two bits for each Category:</p>
@@ -129,7 +134,7 @@
         </td>
     </tr>
     <tr>
-        <td>KnownChildSensitiveDataConsents</td>
+        <td><code>KnownChildSensitiveDataConsents</code></td>
         <td>Int(2)</td>
         <td>
             <p>Consent to process Personal Data from a known Child in accordance with COPPA as required by Minn. Stat. &sect; 325O.07, Subd. 2(d)</p>
@@ -139,7 +144,7 @@
         </td>
     </tr>
     <tr>
-        <td>AdditionalDataProcessingConsent</td>
+        <td><code>AdditionalDataProcessingConsent</code></td>
         <td>Int(2)</td>
         <td>
             <p>Consent to Processing of the Consumer's Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer's Personal Data Was Processed</p>
@@ -149,18 +154,18 @@
         </td>
     </tr>
     <tr>
-        <td>MspaCoveredTransaction</td>
+        <td><code>MspaCoveredTransaction</code></td>
         <td>Int(2)</td>
-        <td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
             <p>Publisher or Advertiser, as applicable, is a signatory to the <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/#">IAB Multi-State Privacy Agreement (MSPA)</a>, as may be amended from time to time, and declares that the transaction is a "Covered Transaction" as defined in the <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/#">MSPA</a>.</p>
             <p><code>1</code> = Yes</p>
             <p><code>2</code> = No</p>
         </td>
     </tr>
     <tr>
-        <td>MspaOptOutOptionMode</td>
+        <td><code>MspaOptOutOptionMode</code></td>
         <td>Int(2)</td>
-        <td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
             <p>Publisher or Advertiser, as applicable, has enabled "Opt-Out Option Mode" for the "Covered Transaction," as such terms are defined in the <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/#">MSPA</a>.</p>
             <p><code>0</code> = Not Applicable</p>
             <p><code>1</code> = Yes</p>
@@ -168,9 +173,9 @@
         </td>
     </tr>
     <tr>
-        <td>MspaServiceProviderMode</td>
+        <td><code>MspaServiceProviderMode</code></td>
         <td>Int(2)</td>
-        <td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
             <p>Publisher or Advertiser, as applicable, has enabled "Service Provider Mode" for the "Covered Transaction," as such terms are defined in the <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.iabprivacy.com/#">MSPA</a>.</p>
             <p><code>0</code> = Not Applicable</p>
             <p><code>1</code> = Yes</p>
@@ -190,15 +195,14 @@
         <td><strong>Description</strong></td>
     </tr>
     <tr>
-        <td>SubsectionType</td>
+        <td><code>SubsectionType</code></td>
         <td>Int(2)</td>
         <td>
-           <p><code>0</code> = Core</p>
             <p><code>1</code> = GPC</p>
         </td>
     </tr>
     <tr>
-        <td>Gpc</td>
+        <td><code>Gpc</code></td>
         <td>Boolean</td>
         <td>
             <p><code>0</code> = false</p>

--- a/Sections/US-States/MN/README.md
+++ b/Sections/US-States/MN/README.md
@@ -1,1 +1,4 @@
+# Minnesota Privacy Technical Specification
+
+
 Contained in this directory are technical specifications for Minnesota privacy strings to support the Minnesota Consumer Data Privacy Act.

--- a/Sections/US-States/MT/GPP Extension: IAB Privacy’s Montana Privacy Technical Specification.md
+++ b/Sections/US-States/MT/GPP Extension: IAB Privacy’s Montana Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-iab-privacy-s-montana-privacy-technical-specification">GPP Extension: IAB Privacy’s Montana Privacy Technical Specification</h1>
+<h1 id="gpp-extension-iab-privacy-s-montana-privacy-technical-specification"> Montana Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Montana section of the GPP specifications in accordance with the IAB Privacy Multi-State Privacy Agreement legal requirements, applicable to both Signatories and non-Signatories of the MSPA.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Montana section of the GPP specifications.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>
@@ -11,7 +11,11 @@
 <td><strong>Version</strong></td>
 <td><strong>Comments</strong></td>
 </tr>
-
+<tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr>
 <tr>
 <td>May 2024</td>
 <td>1.0</td>
@@ -53,8 +57,8 @@
 </div>
 <h3>Section encoding</h3>
 <p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
-<h4>Core Segment</h4>
-<p>The core sub-section must always be present. Where terms are capitalized in the ‘description’ field they are defined terms in Montana Act, Sec. 2 [Pending Codification]. It consists of the following fields:</p>
+<h4>Core Subsection</h4>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined terms in Montana Act, Sec. 2. It consists of the following fields:</p>
 <div>
   <table>
     <thead>
@@ -72,138 +76,120 @@
     </thead>
     <tbody>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Version</span>
-        </td>
+        <td><code>Version</code></td>
         <td>Int(6)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">The version of this section specification used to encode the string.</span>
-        </td>
+        <td>The version of this section specification used to encode the string.</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SharingNotice</span>
-        </td>
+        <td><code>SharingNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Processing of Personal Data.</span><p></p><code>0</code> = Not Applicable,
-          <span style="color:rgb(36, 41, 47);">The Controller does not Process Personal Data</span><p></p><code>1</code> = Yes, notice was provided<p></p><code>2</code> = No, notice was not provided</td>
+        <td>Notice of the Processing of Personal Data.
+        <p></p><code>0</code> = Not Applicable, The Controller does not Process Personal Data
+        <p></p><code>1</code> = Yes, notice was provided
+        <p></p><code>2</code> = No, notice was not provided</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOutNotice</span>
-        </td>
+        <td><code>SaleOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data&nbsp;</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">,
-          </span>The
-          <span style="color:rgb(36, 41, 47);">Controller does not Sell Personal Data</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable, The Controller does not Sell Personal Data
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOutNotice</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">, the Controller does not Process Personal Data for Targeted Advertising</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data for Targeted Advertising
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOut</span>
-        </td>
+        <td><code>SaleOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of the Sale of the Consumer’s Personal Data</span><p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOut</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SensitiveDataProcessing</span>
-        </td>
+        <td><code>SensitiveDataProcessing</code></td>
         <td>N-Bitfield(2,8)</td>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data<p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(2). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Condition or Diagnosis.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(4). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sex Life or Sexual Orientation.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(5). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(6). Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(7). Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(8). Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.</span><p></p>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent
+        <p></p>(1) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.<p></p>
+          (2) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.<p></p>
+          (3) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Condition or Diagnosis.<p></p>
+          (4) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sex Life or Sexual Orientation.<p></p>
+          (5) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.<p></p>
+          (6) Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (7) Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (8) Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.<p></p>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">KnownChildSensitiveDataConsents</span>
-        </td>
+        <td><code>KnownChildSensitiveDataConsents</code></td>
         <td>N-Bitfield(2,3)</td>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not
-          <span style="color:rgb(36, 41, 47);">Process Sensitive Data of a known Child</span><p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Consent to Process Sensitive Data from a Known Child.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(2). Consent to Sell the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Consent to Process the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age for Purposes of Targeted Advertising.</span><p></p>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Sensitive Data of a known Child
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent
+        <p></p>(1) Consent to Process Sensitive Data from a Known Child.<p></p>
+          (2) Consent to Sell the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age.<p></p>
+          (3) Consent to Process the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age for Purposes of Targeted Advertising.<p></p>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">AdditionalDataProcessingConsent</span>
-        </td>
+        <td><code>AdditionalDataProcessingConsent</code></td>
         <td>Int(2)</td>
-        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed<p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)<p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;</td>
+        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaCoveredTransaction</span>
-        </td>
+        <td><code>MspaCoveredTransaction<code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.&nbsp;</span><p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
+<p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaOptOutOptionMode</span>
-        </td>
+        <td><code>MspaOptOutOptionMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaServiceProviderMode</span>
-        </td>
+        <td><code>MspaServiceProviderMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
     </tbody>
   </table>
 </div>
-<h4>GPC Sub-section</h4>
-<p>
-  <a target="_blank" href="https://globalprivacycontrol.github.io/gpc-spec/">
-    <span style="color:rgb(17, 85, 204);">GPC</span>
-  </a>
-  <span style="color:rgb(36, 41, 47);">
-    is signaled in user agent headers
-  </span>
-  <span style="color:rgb(36, 41, 47);">(Sec-GPC)</span>
-  <span style="color:rgb(36, 41, 47);">
-    and a simple javascript API
-  </span>
-  <span style="color:rgb(36, 41, 47);">(globalPrivacyControl)</span>
-  <span style="color:rgb(36, 41, 47);">. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this sub-section.</span>
-</p>
+<h4>GPC Subsection</h4>
+<p><a href="https://w3c.github.io/gpc/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this subsection.</p>
 <div>
   <table>
     <tbody>
@@ -219,12 +205,12 @@
         </td>
       </tr>
       <tr>
-        <td>SubsectionType</td>
+        <td><code>SubsectionType</code></td>
         <td>Int(2)</td>
-        <td><p></p><code>0</code> = Core<p></p><code>1</code> = GPC</td>
+        <td><code>1</code> = GPC</td>
       </tr>
       <tr>
-        <td>Gpc</td>
+        <td><code>Gpc</code></td>
         <td>Boolean</td>
         <td><p></p><code>0</code> = false<p></p><code>1</code> = true</td>
       </tr>

--- a/Sections/US-States/MT/README.md
+++ b/Sections/US-States/MT/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s Montana Privacy Technical Specification
+# Montana Privacy Technical Specification
 
 
  

--- a/Sections/US-States/NE/GPP Extension: IAB Privacy’s Nebraska Privacy Technical Specification.md
+++ b/Sections/US-States/NE/GPP Extension: IAB Privacy’s Nebraska Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-iab-privacy-s-nebraska-privacy-technical-specification">GPP Extension: IAB Privacy’s Nebraska Privacy Technical Specification</h1>
+<h1 id="gpp-extension-iab-privacy-s-nebraska-privacy-technical-specification">Nebraska Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Nebraska section of the GPP specifications in accordance with the IAB Privacy Multi-State Privacy Agreement legal requirements, applicable to both Signatories and non-Signatories of the MSPA.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Nebraska section of the GPP specifications.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>
@@ -11,7 +11,11 @@
 <td><strong>Version</strong></td>
 <td><strong>Comments</strong></td>
 </tr>
-
+<tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr>
 <tr>
 <td>July 2024</td>
 <td>1.0</td>
@@ -53,8 +57,8 @@
 </div>
 <h3>Section encoding</h3>
 <p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
-<h4>Core Segment</h4>
-<p>The core sub-section must always be present. Where terms are capitalized in the ‘description’ field they are defined in the Nebraska Act, Sec. 2 [Pending Codification]. It consists of the following fields:</p>
+<h4>Core Subsection</h4>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined in the Nebraska Act, Sec. 2. It consists of the following fields:</p>
 <div>
   <table>
     <thead>
@@ -72,136 +76,117 @@
     </thead>
     <tbody>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Version</span>
-        </td>
+        <td><code>Version</code></td>
         <td>Int(6)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">The version of this section specification used to encode the string.</span>
-        </td>
+        <td>The version of this section specification used to encode the string.</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">ProcessingNotice</span>
-        </td>
+        <td><code>ProcessingNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Processing of Personal Data.</span><p></p><code>0</code> = Not Applicable,
-          <span style="color:rgb(36, 41, 47);">the Controller does not Process Personal Data</span><p></p><code>1</code> = Yes, notice was provided<p></p><code>2</code> = No, notice was not provided</td>
+        <td>Notice of the Processing of Personal Data.
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data
+        <p></p><code>1</code> = Yes, notice was provided
+        <p></p><code>2</code> = No, notice was not provided</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOutNotice</span>
-        </td>
+        <td><code>SaleOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data&nbsp;</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">,
-          </span>the
-          <span style="color:rgb(36, 41, 47);">Controller does not Sell Personal Data</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>>Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable<,the Controller does not Sell Personal Data
+        <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOutNotice</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">, the Controller does not Process Personal Data for Targeted Advertising</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data for Targeted Advertising
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOut</span>
-        </td>
+        <td><code>SaleOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of the Sale of the Consumer’s Personal Data</span><p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOut</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SensitiveDataProcessing</span>
-        </td>
+        <td><code>SensitiveDataProcessing</code></td>
         <td>N-Bitfield(2,8)</td>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data<p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(2). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Diagnosis.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(4). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sexual Orientation.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(5). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(6). Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(7). Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(8). Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.</span><p></p>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent
+        <p></p>(1) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.<p></p>
+          (2) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.<p></p>
+          (3) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Diagnosis.<p></p>
+          (4) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sexual Orientation.<p></p>
+          (5) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.<p></p>
+          (6) Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (7) Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (8) Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.<p></p>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">KnownChildSensitiveDataConsents</span>
-        </td>
+        <td><code>KnownChildSensitiveDataConsents</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Consent to Process Personal Data from a Known Child.</span><p></p><code>0</code> = Not Applicable, the Controller does not
-          <span style="color:rgb(36, 41, 47);">Process Sensitive Data of a known Child</span><p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;</td>
+        <td>Consent to Process Personal Data from a Known Child.
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Sensitive Data of a known Child
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">AdditionalDataProcessingConsent</span>
-        </td>
+        <td><code>AdditionalDataProcessingConsent</code></td>
         <td>Int(2)</td>
-        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed<p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)<p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;</td>
+        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent</td>
       </tr>
             <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaCoveredTransaction</span>
-        </td>
+        <td><code>MspaCoveredTransaction</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.&nbsp;</span><p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
+<p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaOptOutOptionMode</span>
-        </td>
+        <td><code>MspaOptOutOptionMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaServiceProviderMode</span>
-        </td>
+        <td><code>MspaServiceProviderMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
     </tbody>
   </table>
 </div>
-<h4>GPC Sub-section</h4>
-<p>
-  <a target="_blank" href="https://globalprivacycontrol.github.io/gpc-spec/">
-    <span style="color:rgb(17, 85, 204);">GPC</span>
-  </a>
-  <span style="color:rgb(36, 41, 47);">
-    is signaled in user agent headers
-  </span>
-  <span style="color:rgb(36, 41, 47);">(Sec-GPC)</span>
-  <span style="color:rgb(36, 41, 47);">
-    and a simple javascript API
-  </span>
-  <span style="color:rgb(36, 41, 47);">(globalPrivacyControl)</span>
-  <span style="color:rgb(36, 41, 47);">. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this sub-section.</span>
-</p>
+<h4>GPC Subsection</h4>
+<p><a href="https://w3c.github.io/gpc/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this subsection.</p>
+
 <div>
   <table>
     <tbody>
@@ -217,12 +202,12 @@
         </td>
       </tr>
       <tr>
-        <td>SubsectionType</td>
+        <td><code>SubsectionType<code></td>
         <td>Int(2)</td>
-        <td><p></p><code>0</code> = Core<p></p><code>1</code> = GPC</td>
+        <td><code>1</code> = GPC</td>
       </tr>
       <tr>
-        <td>Gpc</td>
+        <td><code>Gpc</code></td>
         <td>Boolean</td>
         <td><p></p><code>0</code> = false<p></p><code>1</code> = true</td>
       </tr>

--- a/Sections/US-States/NE/README.md
+++ b/Sections/US-States/NE/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s Nebraska Privacy Technical Specification
+# Nebraska Privacy Technical Specification
 
 
  

--- a/Sections/US-States/NH/GPP Extension: IAB Privacy’s New Hampshire Privacy Technical Specification.md
+++ b/Sections/US-States/NH/GPP Extension: IAB Privacy’s New Hampshire Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-iab-privacy-s-new-hampshire-privacy-technical-specification">GPP Extension: IAB Privacy’s New Hampshire Privacy Technical Specification</h1>
+<h1 id="gpp-extension-iab-privacy-s-new-hampshire-privacy-technical-specification">New Hampshire Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the New Hampshire section of the GPP specifications in accordance with the IAB Privacy Multi-State Privacy Agreement legal requirements, applicable to both Signatories and non-Signatories of the MSPA.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the New Hampshire section of the GPP specifications.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>
@@ -11,7 +11,11 @@
 <td><strong>Version</strong></td>
 <td><strong>Comments</strong></td>
 </tr>
-
+<tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr>
 <tr>
 <td>July 2024</td>
 <td>1.0</td>
@@ -53,8 +57,8 @@
 </div>
 <h3>Section encoding</h3>
 <p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
-<h4>Core Segment</h4>
-<p>The core sub-section must always be present. Where terms are capitalized in the ‘description’ field they are defined in the New Hampshire Expectation of Privacy law, N.H. Rev. Stat. 507-H:1 et seq. It consists of the following fields:</p>
+<h4>Core Subsection</h4>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined in the New Hampshire Expectation of Privacy law, N.H. Rev. Stat. 507-H:1 et seq. It consists of the following fields:</p>
 <div>
   <table>
     <thead>
@@ -72,138 +76,120 @@
     </thead>
     <tbody>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Version</span>
-        </td>
+        <td><code>Version</code></td>
         <td>Int(6)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">The version of this section specification used to encode the string.</span>
-        </td>
+        <td>The version of this section specification used to encode the string.</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">ProcessingNotice</span>
-        </td>
+        <td><code>ProcessingNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Processing of Personal Data.</span><p></p><code>0</code> = Not Applicable,
-          <span style="color:rgb(36, 41, 47);">the Controller does not Process Personal Data</span><p></p><code>1</code> = Yes, notice was provided<p></p><code>2</code> = No, notice was not provided</td>
+        <td>Notice of the Processing of Personal Data.
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data
+        <p></p><code>1</code> = Yes, notice was provided
+        <p></p><code>2</code> = No, notice was not provided</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOutNotice</span>
-        </td>
+        <td><code>SaleOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data&nbsp;</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">,
-          </span>the
-          <span style="color:rgb(36, 41, 47);">Controller does not Sell Personal Data</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable,the Controller does not Sell Personal Data
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOutNotice</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">, the Controller does not Process Personal Data for Targeted Advertising</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data for Targeted Advertising
+          <p></p><code>1</code> = Yes, notice was provided
+          =<p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOut</span>
-        </td>
+        <td><code>SaleOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of the Sale of the Consumer’s Personal Data</span><p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOut</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SensitiveDataProcessing</span>
-        </td>
+        <td><code>SensitiveDataProcessing</code></td>
         <td>N-Bitfield(2,8)</td>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data<p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(2). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Condition or Diagnosis.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(4). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sex Life or Sexual Orientation.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(5). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(6). Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(7). Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(8). Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.</span><p></p>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent
+        <p></p>(1) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.<p></p>
+          (2) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.<p></p>
+          (3) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Condition or Diagnosis.<p></p>
+          (4) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sex Life or Sexual Orientation.<p></p>
+          (5) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.<p></p>
+          (6) Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (7) Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (8) Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.<p></p>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">KnownChildSensitiveDataConsents</span>
-        </td>
+        <td><code>KnownChildSensitiveDataConsents</code></td>
         <td>N-Bitfield(2,3)</td>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not
-          <span style="color:rgb(36, 41, 47);">Process Sensitive Data of a known Child</span><p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Consent to Process Sensitive Data from a Known Child.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(2). Consent to Sell the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Consent to Process the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age for Purposes of Targeted Advertising.</span><p></p>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Sensitive Data of a known Child
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent
+        <p></p>(1) Consent to Process Sensitive Data from a Known Child.<p></p>
+          (2) Consent to Sell the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age.<p></p>
+          (3) Consent to Process the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age for Purposes of Targeted Advertising.<p></p>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">AdditionalDataProcessingConsent</span>
-        </td>
+        <td><code>AdditionalDataProcessingConsent</code></td>
         <td>Int(2)</td>
-        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed<p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)<p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;</td>
+        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaCoveredTransaction</span>
-        </td>
+        <td><code>MspaCoveredTransaction</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.&nbsp;</span><p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
+<p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaOptOutOptionMode</span>
-        </td>
+        <td><code>MspaOptOutOptionMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaServiceProviderMode</span>
-        </td>
+        <td><code>MspaServiceProviderMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
     </tbody>
   </table>
 </div>
-<h4>GPC Sub-section</h4>
-<p>
-  <a target="_blank" href="https://globalprivacycontrol.github.io/gpc-spec/">
-    <span style="color:rgb(17, 85, 204);">GPC</span>
-  </a>
-  <span style="color:rgb(36, 41, 47);">
-    is signaled in user agent headers
-  </span>
-  <span style="color:rgb(36, 41, 47);">(Sec-GPC)</span>
-  <span style="color:rgb(36, 41, 47);">
-    and a simple javascript API
-  </span>
-  <span style="color:rgb(36, 41, 47);">(globalPrivacyControl)</span>
-  <span style="color:rgb(36, 41, 47);">. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this sub-section.</span>
-</p>
+<h4>GPC Subsection</h4>
+<p><a href="https://w3c.github.io/gpc/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this subsection.</p>
 <div>
   <table>
     <tbody>
@@ -219,12 +205,12 @@
         </td>
       </tr>
       <tr>
-        <td>SubsectionType</td>
+        <td><code>SubsectionType</code></td>
         <td>Int(2)</td>
-        <td><p></p><code>0</code> = Core<p></p><code>1</code> = GPC</td>
+        <td><code>1</code> = GPC</td>
       </tr>
       <tr>
-        <td>Gpc</td>
+        <td><code>Gpc</code></td>
         <td>Boolean</td>
         <td><p></p><code>0</code> = false<p></p><code>1</code> = true</td>
       </tr>

--- a/Sections/US-States/NH/README.md
+++ b/Sections/US-States/NH/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s New Hampshire Privacy Technical Specification
+# New Hampshire Privacy Technical Specification
 
 
  

--- a/Sections/US-States/NJ/GPP Extension: IAB Privacy’s New Jersey Privacy Technical Specification.md
+++ b/Sections/US-States/NJ/GPP Extension: IAB Privacy’s New Jersey Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-iab-privacy-s-new-jersey-privacy-technical-specification">GPP Extension: IAB Privacy’s New Jersey Privacy Technical Specification</h1>
+<h1 id="gpp-extension-iab-privacy-s-new-jersey-privacy-technical-specification">New Jersey Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the New Jersey section of the GPP specifications in accordance with the IAB Privacy Multi-State Privacy Agreement legal requirements, applicable to both Signatories and non-Signatories of the MSPA.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the New Jersey section of the GPP specifications.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>
@@ -11,7 +11,11 @@
 <td><strong>Version</strong></td>
 <td><strong>Comments</strong></td>
 </tr>
-
+<tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr>
 <tr>
 <td>July 2024</td>
 <td>1.0</td>
@@ -53,8 +57,8 @@
 </div>
 <h3>Section encoding</h3>
 <p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
-<h4>Core Segment</h4>
-<p>The core sub-section must always be present. Where terms are capitalized in the ‘description’ field they are defined in the New Jersey Act Concerning Online Services, Consumers, and Personal Data, P.L. 2023, c. 266. It consists of the following fields:</p>
+<h4>Core Subsection</h4>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined in the New Jersey Act Concerning Online Services, Consumers, and Personal Data, P.L. 2023, c. 266. It consists of the following fields:</p>
 <div>
   <table>
     <thead>
@@ -72,142 +76,124 @@
     </thead>
     <tbody>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Version</span>
-        </td>
+        <td><code>Version<code></td>
         <td>Int(6)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">The version of this section specification used to encode the string.</span>
-        </td>
+        <td>>The version of this section specification used to encode the string.</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">ProcessingNotice</span>
-        </td>
+        <td><code>ProcessingNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Processing of Personal Data.</span><p></p><code>0</code> = Not Applicable,
-          <span style="color:rgb(36, 41, 47);">the Controller does not Process Personal Data</span><p></p><code>1</code> = Yes, notice was provided<p></p><code>2</code> = No, notice was not provided</td>
+        <td>Notice of the Processing of Personal Data.
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data
+        <p></p><code>1</code> = Yes, notice was provided
+        <p></p><code>2</code> = No, notice was not provided</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOutNotice</span>
-        </td>
+        <td><code>SaleOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data&nbsp;</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">,
-          </span>the
-          <span style="color:rgb(36, 41, 47);">Controller does not Sell Personal Data</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable, the Controller does not Sell Personal Data
+        <p></p><code>1</code> = Yes, notice was provided
+        <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOutNotice</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">, the Controller does not Process Personal Data for Targeted Advertising</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data for Targeted Advertising
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOut</span>
-        </td>
+        <td><code>SaleOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of the Sale of the Consumer’s Personal Data</span><p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOut</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SensitiveDataProcessing</span>
-        </td>
+        <td><code>SensitiveDataProcessing</code></td>
         <td>N-Bitfield(2,10)</td>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data<p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(2). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Condition, Treatment, or Diagnosis.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(4). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sex Life or Sexual Orientation.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(5). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(6). Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(7). Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(8). Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(9). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Status as Transgender or Nonbinary.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(10). Consent to Process the Consumer’s Sensitive Data Consisting of Financial Information, in Combination with any Required Security Code, Access Code, or Password that Would Permit Access to a Consumer’s Financial Account.</span><p></p>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent
+        <p></p>(1) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.<p></p>
+          (2) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.<p></p>
+          (3) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Condition, Treatment, or Diagnosis.<p></p>
+          (4) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sex Life or Sexual Orientation.<p></p>
+          (5) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.<p></p>
+          (6) Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (7) Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (8) Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.<p></p>
+          (9) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Status as Transgender or Nonbinary.<p></p>
+          (10) Consent to Process the Consumer’s Sensitive Data Consisting of Financial Information, in Combination with any Required Security Code, Access Code, or Password that Would Permit Access to a Consumer’s Financial Account.<p></p>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">KnownChildSensitiveDataConsents</span>
-        </td>
+        <td><code>KnownChildSensitiveDataConsents</code></td>
         <td>N-Bitfield(2,5)</td>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not
-          <span style="color:rgb(36, 41, 47);">Process Sensitive Data of a known Child</span><p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Consent to Process Sensitive Data from a Known Child.</span>
-          <span style="color:rgb(36, 41, 47);">(2). Consent to Sell the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Consent to Process the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age for Purposes of Targeted Advertising.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(4). Consent to Sell the Personal Data of Consumers At Least 16 Years of Age but Younger Than 17 Years of Age.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(5). Consent to Process the Personal Data of Consumers At Least 16 Years of Age but Younger Than 17 Years of Age for Purposes of Targeted Advertising.</span><p></p>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Sensitive Data of a known Child
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent
+        <p></p>(1) Consent to Process Sensitive Data from a Known Child.
+          (2) Consent to Sell the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age.<p></p>
+          (3) Consent to Process the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age for Purposes of Targeted Advertising.<p></p>
+          (4) Consent to Sell the Personal Data of Consumers At Least 16 Years of Age but Younger Than 17 Years of Age.<p></p>
+          (5) Consent to Process the Personal Data of Consumers At Least 16 Years of Age but Younger Than 17 Years of Age for Purposes of Targeted Advertising.<p></p>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">AdditionalDataProcessingConsent</span>
-        </td>
+        <td><code>AdditionalDataProcessingConsent</code></td>
         <td>Int(2)</td>
-        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed<p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)<p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;</td>
+        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaCoveredTransaction</span>
-        </td>
+        <td><code>MspaCoveredTransaction</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.&nbsp;</span><p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
+<p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaOptOutOptionMode</span>
-        </td>
+        <td><code>>MspaOptOutOptionMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaServiceProviderMode</span>
-        </td>
+        <td><code>MspaServiceProviderMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
     </tbody>
   </table>
 </div>
-<h4>GPC Sub-section</h4>
-<p>
-  <a target="_blank" href="https://globalprivacycontrol.github.io/gpc-spec/">
-    <span style="color:rgb(17, 85, 204);">GPC</span>
-  </a>
-  <span style="color:rgb(36, 41, 47);">
-    is signaled in user agent headers
-  </span>
-  <span style="color:rgb(36, 41, 47);">(Sec-GPC)</span>
-  <span style="color:rgb(36, 41, 47);">
-    and a simple javascript API
-  </span>
-  <span style="color:rgb(36, 41, 47);">(globalPrivacyControl)</span>
-  <span style="color:rgb(36, 41, 47);">. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this sub-section.</span>
-</p>
+<h4>GPC Subsection</h4>
+<p><a href="https://w3c.github.io/gpc/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this subsection.</p>
 <div>
   <table>
     <tbody>
@@ -223,12 +209,12 @@
         </td>
       </tr>
       <tr>
-        <td>SubsectionType</td>
+        <td><code>SubsectionType</code></td>
         <td>Int(2)</td>
-        <td><p></p><code>0</code> = Core<p></p><code>1</code> = GPC</td>
+        <td><code>1</code> = GPC</td>
       </tr>
       <tr>
-        <td>Gpc</td>
+        <td><code>Gpc</code></td>
         <td>Boolean</td>
         <td><p></p><code>0</code> = false<p></p><code>1</code> = true</td>
       </tr>

--- a/Sections/US-States/NJ/README.md
+++ b/Sections/US-States/NJ/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s New Jersey Privacy Technical Specification
+# New Jersey Privacy Technical Specification
 
 
  

--- a/Sections/US-States/OR/GPP Extension: IAB Privacy’s Oregon Privacy Technical Specification.md
+++ b/Sections/US-States/OR/GPP Extension: IAB Privacy’s Oregon Privacy Technical Specification.md
@@ -1,8 +1,8 @@
-<h1 id="gpp-extension-iab-privacy-s-oregon-privacy-technical-specification">GPP Extension: IAB Privacy’s Oregon Privacy Technical Specification</h1>
+<h1 id="gpp-extension-iab-privacy-s-oregon-privacy-technical-specification">Oregon Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Oregon section of the GPP specifications in accordance with the IAB Privacy Multi-State Privacy Agreement legal requirements, applicable to both Signatories and non-Signatories of the MSPA.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Oregon section of the GPP specifications.</p>
 
-<h3>Version History&nbsp;</h3>
+<h3>Version History</h3>
 <div>
 <table>
 <tbody>
@@ -11,7 +11,11 @@
 <td><strong>Version</strong></td>
 <td><strong>Comments</strong></td>
 </tr>
-
+<tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr>
 <tr>
 <td>May 2024</td>
 <td>1.0</td>
@@ -53,8 +57,8 @@
 </div>
 <h3>Section encoding</h3>
 <p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
-<h4>Core Segment</h4>
-<p>The core sub-section must always be present. Where terms are capitalized in the ‘description’ field they are defined terms in Oregon Act, Sec. 2 [Pending Codification]. It consists of the following fields:</p>
+<h4>Core Subsection</h4>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined terms in Oregon Act, Sec. 2. It consists of the following fields:</p>
 <div>
   <table>
     <thead>
@@ -72,141 +76,123 @@
     </thead>
     <tbody>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Version</span>
-        </td>
+        <td><code>Version</code></td>
         <td>Int(6)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">The version of this section specification used to encode the string.</span>
-        </td>
+        <td>The version of this section specification used to encode the string.</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">ProcessingNotice</span>
-        </td>
+        <td><code>ProcessingNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Processing of Personal Data.</span><p></p><code>0</code> = Not Applicable,
-          <span style="color:rgb(36, 41, 47);">The Controller does not Process Personal Data</span><p></p><code>1</code> = Yes, notice was provided<p></p><code>2</code>= No, notice was not provided</td>
+        <td>Notice of the Processing of Personal Data.
+        <p></p><code>0</code> = Not Applicable, The Controller does not Process Personal Data
+        <p></p><code>1</code> = Yes, notice was provided
+        <p></p><code>2</code>= No, notice was not provided</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOutNotice</span>
-        </td>
+        <td><code>SaleOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data&nbsp;</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">,
-          </span>The
-          <span style="color:rgb(36, 41, 47);">Controller does not Sell Personal Data</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>>Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable, The Controller does not Sell Personal Data
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOutNotice</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">, the Controller does not Process Personal Data for Targeted Advertising</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data for Targeted Advertising
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOut</span>
-        </td>
+        <td><code>SaleOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of the Sale of the Consumer’s Personal Data</span><p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOut</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SensitiveDataProcessing</span>
-        </td>
+        <td><code>SensitiveDataProcessing</code></td>
         <td>N-Bitfield(2,11)</td>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data<p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(2). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Condition or Diagnosis.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(4). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sexual Orientation.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(5). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Status as Transgender or Nonbinary.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(6). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(7). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing National Origin.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(8). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Status as Victim of a Crime.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(9). Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(10). Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(11). Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.</span><p></p>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent
+        <p></p>(1) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.<p></p>
+          (2) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.<p></p>
+          (3) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Condition or Diagnosis.<p></p>
+          (4) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sexual Orientation.<p></p>
+          (5) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Status as Transgender or Nonbinary.<p></p>
+          (6) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.<p></p>
+          (7) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing National Origin.<p></p>
+          (8) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Status as Victim of a Crime.<p></p>
+          (9) Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data.<p></p>
+          (10) Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data.<p></p>
+          (11) Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.<p></p>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">KnownChildSensitiveDataConsents</span>
-        </td>
+        <td><code>KnownChildSensitiveDataConsents</code></td>
         <td>N-Bitfield(2,3)</td>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not
-          <span style="color:rgb(36, 41, 47);">Process Sensitive Data of a known Child</span><p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Consent to Process Sensitive Data from a Known Child.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(2). Consent to Sell the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Consent to Process the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age for Purposes of Targeted Advertising.</span><p></p>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Sensitive Data of a known Child
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent
+        <p></p>(1) Consent to Process Sensitive Data from a Known Child.<p></p>
+          (2) Consent to Sell the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age.<p></p>
+          (3) Consent to Process the Personal Data of Consumers At Least 13 Years of Age but Younger Than 16 Years of Age for Purposes of Targeted Advertising.<p></p>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">AdditionalDataProcessingConsent</span>
-        </td>
+        <td><code>AdditionalDataProcessingConsent</code></td>
         <td>Int(2)</td>
-        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed<p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)<p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;</td>
+        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaCoveredTransaction</span>
-        </td>
+        <td><code>MspaCoveredTransaction</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.&nbsp;</span><p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
+<p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaOptOutOptionMode</span>
-        </td>
+        <td><code>MspaOptOutOptionMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaServiceProviderMode</span>
-        </td>
+        <td><code>MspaServiceProviderMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
     </tbody>
   </table>
 </div>
-<h4>GPC Sub-section</h4>
-<p>
-  <a target="_blank" href="https://globalprivacycontrol.github.io/gpc-spec/">
-    <span style="color:rgb(17, 85, 204);">GPC</span>
-  </a>
-  <span style="color:rgb(36, 41, 47);">
-    is signaled in user agent headers
-  </span>
-  <span style="color:rgb(36, 41, 47);"><code>(Sec-GPC)</code></span>
-  <span style="color:rgb(36, 41, 47);">
-    and a simple javascript API
-  </span>
-  <span style="color:rgb(36, 41, 47);"><code>(globalPrivacyControl)</code></span>
-  <span style="color:rgb(36, 41, 47);">. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this sub-section.</span>
-</p>
+<h4>GPC Subsection</h4>
+<p><a href="https://w3c.github.io/gpc/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this subsection.</p>
 <div>
   <table>
     <tbody>
@@ -222,12 +208,12 @@
         </td>
       </tr>
       <tr>
-        <td>SubsectionType</td>
+        <td><code>SubsectionType</code></td>
         <td>Int(2)</td>
-        <td><p></p><code>0</code> = Core<p></p><code>1</code> = GPC</td>
+        <td><code>1</code> = GPC</td>
       </tr>
       <tr>
-        <td>Gpc</td>
+        <td><code>Gpc</code></td>
         <td>Boolean</td>
         <td><p></p><code>0</code> = false<p></p><code>1</code> = true</td>
       </tr>

--- a/Sections/US-States/OR/README.md
+++ b/Sections/US-States/OR/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s Oregon Privacy Technical Specification
+# Oregon Privacy Technical Specification
 
 
  

--- a/Sections/US-States/RI/README.md
+++ b/Sections/US-States/RI/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s Rhode Island Privacy Technical Specification
+# Rhode Island Privacy Technical Specification
 
 
  

--- a/Sections/US-States/RI/Rhode Island Privacy Technical Specification.md
+++ b/Sections/US-States/RI/Rhode Island Privacy Technical Specification.md
@@ -11,6 +11,11 @@
     <td><strong>Comments</strong></td>
 </tr>
 <tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr>
+<tr>
 <td>April 2026</td>
     <td>1.0</td>
     <td>Updated SubSections field in Section header to never include Core subsection</td>
@@ -59,7 +64,7 @@
       <td><strong>Field Description</strong></td>
     </tr>
     <tr>
-      <td>Section ID</td>
+      <td>SectionID</td>
       <td>Int(6)</td>
       <td><p>Section ID from the Section IDs list.</p></td>
     </tr>
@@ -85,7 +90,7 @@
     </tr>
     <tr>
       <td>0</td>
-      <td><p>Core</p></td>
+      <td>Core</td>
     </tr>
     <tr>
       <td>1</td>
@@ -102,23 +107,23 @@
       <td><strong>Field Description</strong></td>
     </tr>
     <tr>
-      <td>MspaVersion</td>
+      <td><code>MspaVersion</code></td>
       <td>Int(6)</td>
-      <td><p>Version of the MSPA</p></td>
+      <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b><p>Version of the MSPA</p></td>
     </tr>
     <tr>
-      <td>MspaCoveredTransaction</td>
+      <td><code>MspaCoveredTransaction</code></td>
       <td>Int(2)</td>
-      <td>
+      <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
         <p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.</p>
         <p><code>1</code> = Yes</p>
         <p><code>2</code> = No</p>
       </td>
     </tr>
     <tr>
-      <td>MspaMode</td>
+      <td><code>MspaMode</code></td>
       <td>Int(2)</td>
-      <td>
+      <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
         <p>Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</p>
         <p>Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</p>
         <p><code>0</code> = Not Applicable</p>
@@ -127,7 +132,7 @@
       </td>
     </tr>
     <tr>
-      <td>ProcessingNotice</td>
+      <td><code>ProcessingNotice</code></td>
       <td>Int(2)</td>
       <td>
         <p>Notice Describing Processing of Personal Data.</p>
@@ -137,7 +142,7 @@
       </td>
     </tr>
     <tr>
-      <td>SaleOptOutNotice</td>
+      <td><code>SaleOptOutNotice</code></td>
       <td>Int(2)</td>
       <td>
         <p>Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data</p>
@@ -147,7 +152,7 @@
       </td>
     </tr>
     <tr>
-      <td>TargetedAdvertisingOptOutNotice</td>
+      <td><code>TargetedAdvertisingOptOutNotice</code></td>
       <td>Int(2)</td>
       <td>
         <p>Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising</p>
@@ -157,7 +162,7 @@
       </td>
     </tr>
     <tr>
-      <td>SaleOptOut</td>
+      <td><code>SaleOptOut</code></td>
       <td>Int(2)</td>
       <td>
         <p>Opt-Out of the Sale of the Consumer’s Personal Data</p>
@@ -167,7 +172,7 @@
       </td>
     </tr>
     <tr>
-      <td>TargetedAdvertisingOptOut</td>
+      <td><code>TargetedAdvertisingOptOut</code></td>
       <td>Int(2)</td>
       <td>
         <p>Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising</p>
@@ -177,7 +182,7 @@
       </td>
     </tr>
     <tr>
-      <td>KnownChildSensitiveDataConsents</td>
+      <td><code>KnownChildSensitiveDataConsents</code></td>
       <td>Int(2)</td>
       <td>
         <p>Consent to process Personal Data concerning a known Child in accordance with COPPA as required by Rhode Island Act 6-48.1-4(c)</p>
@@ -187,7 +192,7 @@
       </td>
     </tr>
     <tr>
-      <td>AdditionalDataProcessingConsent</td>
+      <td><code>AdditionalDataProcessingConsent</code></td>
       <td>Int(2)</td>
       <td>
         <p>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed</p>
@@ -207,7 +212,7 @@
       <td><strong>Field Description</strong></td>
     </tr>
     <tr>
-      <td>SensitiveDataProcessing</td>
+      <td><code>SensitiveDataProcessing</code></td>
       <td>N-Bitfield(2,8)</td>
       <td>
         <p>Consent from the Consumer to Process his or her Sensitive Data in accordance with Rhode Island Act 6-48.1-4(c).</p>

--- a/Sections/US-States/TN/GPP Extension: IAB Privacy’s Tennessee Privacy Technical Specification.md
+++ b/Sections/US-States/TN/GPP Extension: IAB Privacy’s Tennessee Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-iab-privacy-s-tennessee-privacy-technical-specification">GPP Extension: IAB Privacy’s Tennessee Privacy Technical Specification</h1>
+<h1 id="gpp-extension-iab-privacy-s-tennessee-privacy-technical-specification">Tennessee Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Tennessee section of the GPP specifications in accordance with the IAB Privacy Multi-State Privacy Agreement legal requirements, applicable to both Signatories and non-Signatories of the MSPA.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Tennessee section of the GPP specifications.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>
@@ -11,7 +11,11 @@
 <td><strong>Version</strong></td>
 <td><strong>Comments</strong></td>
 </tr>
-
+<tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr>
 <tr>
 <td>July 2024</td>
 <td>1.0</td>
@@ -53,8 +57,8 @@
 </div>
 <h3>Section encoding</h3>
 <p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
-<h4>Core Segment</h4>
-<p>The core sub-section must always be present. Where terms are capitalized in the ‘description’ field they are defined in Tenn. Code Ann. 47-18-3301. It consists of the following fields:</p>
+<h4>Core Subsection</h4>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined in Tenn. Code Ann. 47-18-3301. It consists of the following fields:</p>
 <div>
   <table>
     <thead>
@@ -72,136 +76,116 @@
     </thead>
     <tbody>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Version</span>
-        </td>
+        <td><code>Version</code></td>
         <td>Int(6)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">The version of this section specification used to encode the string.</span>
-        </td>
+        <td>The version of this section specification used to encode the string.</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">ProcessingNotice</span>
-        </td>
+        <td><code>ProcessingNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Processing of Personal Information.</span><p></p><code>0</code> = Not Applicable,
-          <span style="color:rgb(36, 41, 47);">the Controller does not Process Personal Data</span><p></p><code>1</code> = Yes, notice was provided<p></p><code>2</code> = No, notice was not provided</td>
+        <td>Notice of the Processing of Personal Information.
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data
+        <p></p><code>1</code> = Yes, notice was provided
+        <p></p><code>2</code> = No, notice was not provided</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOutNotice</span>
-        </td>
+        <td><code>SaleOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Information&nbsp;</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">,
-          </span>the
-          <span style="color:rgb(36, 41, 47);">Controller does not Sell Personal Data</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Information
+        <p></p><code>0</code> = Not Applicable, the Controller does not Sell Personal Data
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOutNotice</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Information for Targeted Advertising</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">, the Controller does not Process Personal Data for Targeted Advertising</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Information for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data for Targeted Advertising
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOut</span>
-        </td>
+        <td><code>SaleOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of the Sale of the Consumer’s Personal Information</span><p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of the Sale of the Consumer’s Personal Information
+        <p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOut</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of Processing the Consumer’s Personal Information for Targeted Advertising</span><p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of Processing the Consumer’s Personal Information for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SensitiveDataProcessing</span>
-        </td>
+        <td><code>>SensitiveDataProcessing</code></td>
         <td>N-Bitfield(2,8)</td>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data<p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Information Revealing Racial or Ethnic Origin.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(2). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Information Revealing Religious Beliefs.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Information Revealing a Mental or Physical Health Diagnosis.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(4). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Information Revealing Sexual Orientation.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(5). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Information Revealing Citizenship or Immigration Status.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(6). Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(7). Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(8). Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.</span><p></p>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent
+        <p></p>(1) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Information Revealing Racial or Ethnic Origin.><p></p>
+          (2) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Information Revealing Religious Beliefs.<p></p>
+          (3) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Information Revealing a Mental or Physical Health Diagnosis.<p></p>
+          (4) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Information Revealing Sexual Orientation.<p></p>
+          (5) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Information Revealing Citizenship or Immigration Status.<p></p>
+          (6) Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (7) Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (8) Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.<p></p>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">KnownChildSensitiveDataConsent</span>
-        </td>
+        <td><code>KnownChildSensitiveDataConsent</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Consent to Process Sensitive Data from a Known Child.</span><p></p><code>0</code> = Not Applicable, the Controller does not
-          <span style="color:rgb(36, 41, 47);">Process Sensitive Data of a known Child</span><p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;</td>
+        <td>Consent to Process Sensitive Data from a Known Child.
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Sensitive Data of a known Child
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">AdditionalDataProcessingConsent</span>
-        </td>
+        <td><code>AdditionalDataProcessingConsent</code></td>
         <td>Int(2)</td>
-        <td>Consent to Processing of the Consumer’s Personal Information that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Information Was Processed<p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)<p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;</td>
+        <td>Consent to Processing of the Consumer’s Personal Information that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Information Was Processed
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent</td>
          <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaCoveredTransaction</span>
-        </td>
+        <td><code>MspaCoveredTransaction</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.&nbsp;</span><p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
+<p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaOptOutOptionMode</span>
-        </td>
+        <td><code>MspaOptOutOptionMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaServiceProviderMode</span>
-        </td>
+        <td><code>MspaServiceProviderMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
     </tbody>
   </table>
 </div>
-<h4>GPC Sub-section</h4>
-<p>
-  <a target="_blank" href="https://globalprivacycontrol.github.io/gpc-spec/">
-    <span style="color:rgb(17, 85, 204);">GPC</span>
-  </a>
-  <span style="color:rgb(36, 41, 47);">
-    is signaled in user agent headers
-  </span>
-  <span style="color:rgb(36, 41, 47);">(Sec-GPC)</span>
-  <span style="color:rgb(36, 41, 47);">
-    and a simple javascript API
-  </span>
-  <span style="color:rgb(36, 41, 47);">(globalPrivacyControl)</span>
-  <span style="color:rgb(36, 41, 47);">. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this sub-section.</span>
-</p>
+<h4>GPC Subsection</h4>
+<p><a href="https://w3c.github.io/gpc/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this subsection.</p>
 <div>
   <table>
     <tbody>
@@ -217,12 +201,12 @@
         </td>
       </tr>
       <tr>
-        <td>SubsectionType</td>
+        <td><code>SubsectionType</code></td>
         <td>Int(2)</td>
-        <td><p></p><code>0</code> = Core<p></p><code>1</code> = GPC</td>
+        <td><code>1</code> = GPC</td>
       </tr>
       <tr>
-        <td>Gpc</td>
+        <td><code>Gpc</code></td>
         <td>Boolean</td>
         <td><p></p><code>0</code> = false<p></p><code>1</code> = true</td>
       </tr>

--- a/Sections/US-States/TN/README.md
+++ b/Sections/US-States/TN/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s Tennessee Privacy Technical Specification
+# Tennessee Privacy Technical Specification
 
 
  

--- a/Sections/US-States/TX/GPP Extension: IAB Privacy’s Texas Privacy Technical Specification.md
+++ b/Sections/US-States/TX/GPP Extension: IAB Privacy’s Texas Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-iab-privacy-s-texas-privacy-technical-specification">GPP Extension: IAB Privacy’s Texas Privacy Technical Specification</h1>
+<h1 id="gpp-extension-iab-privacy-s-texas-privacy-technical-specification">Texas Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Texas section of the GPP specifications in accordance with the IAB Privacy Multi-State Privacy Agreement legal requirements, applicable to both Signatories and non-Signatories of the MSPA.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; into the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Texas section of the GPP specifications.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>
@@ -11,7 +11,11 @@
 <td><strong>Version</strong></td>
 <td><strong>Comments</strong></td>
 </tr>
-
+<tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
+</tr>
 <tr>
 <td>May 2024</td>
 <td>1.0</td>
@@ -53,8 +57,8 @@
 </div>
 <h3>Section encoding</h3>
 <p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
-<h4>Core Segment</h4>
-<p>The core sub-section must always be present. Where terms are capitalized in the ‘description’ field they are defined terms in Tex. Bus. &amp; Com. Code § 541.001. It consists of the following fields:</p>
+<h4>Core Subsection</h4>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined terms in Tex. Bus. &amp; Com. Code § 541.001. It consists of the following fields:</p>
 <div>
   <table>
     <thead>
@@ -72,136 +76,119 @@
     </thead>
     <tbody>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Version</span>
-        </td>
+        <td><code>Version</code></td>
         <td>Int(6)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">The version of this section specification used to encode the string.</span>
+        <td>The version of this section specification used to encode the string.</span>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">ProcessingNotice</span>
-        </td>
+        <td><code>ProcessingNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Processing of Personal Data.</span><p></p><code>0</code> = Not Applicable,
-          <span style="color:rgb(36, 41, 47);">The Controller does not Process Personal Data</span><p></p><code>1</code> = Yes, notice was provided<p></p><code>2</code> = No, notice was not provided</td>
+        <td>Notice of the Processing of Personal Data.
+        <p></p><code>0</code> = Not Applicable, The Controller does not Process Personal Data
+        <p></p><code>1</code> = Yes, notice was provided
+        <p></p><code>2</code> = No, notice was not provided</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOutNotice</span>
-        </td>
+        <td><code>SaleOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data&nbsp;</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">,
-          </span>The
-          <span style="color:rgb(36, 41, 47);">Controller does not Sell Personal Data</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable, The Controller does not Sell Personal Data
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOutNotice</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOutNotice</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable<span style="color:rgb(36, 41, 47);">, the Controller does not Process Personal Data for Targeted Advertising</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>1</code> = Yes, notice was provided</span>
-          <span style="color:rgb(36, 41, 47);"><p></p><code>2</code> = No, notice was not provided</span>
+        <td>Notice of the Opportunity to Opt Out of Processing of the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data for Targeted Advertising
+          <p></p><code>1</code> = Yes, notice was provided
+          <p></p><code>2</code> = No, notice was not provided
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SaleOptOut</span>
-        </td>
+        <td><code>SaleOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of the Sale of the Consumer’s Personal Data</span><p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of the Sale of the Consumer’s Personal Data
+        <p></p><code>0</code> = Not Applicable, SaleOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">TargetedAdvertisingOptOut</span>
-        </td>
+        <td><code>TargetedAdvertisingOptOut</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising</span><p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided<p></p><code>1</code> = Opted Out<p></p><code>2</code> = Did Not Opt Out</td>
+        <td>Opt-Out of Processing the Consumer’s Personal Data for Targeted Advertising
+        <p></p><code>0</code> = Not Applicable, TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided
+        <p></p><code>1</code> = Opted Out
+        <p></p><code>2</code> = Did Not Opt Out</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">SensitiveDataProcessing</span>
-        </td>
+        <td><code>SensitiveDataProcessing</code></td>
         <td>N-Bitfield(2,8)</td><p></p>
-        <td>Two bits for each Data Activity:<p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data<p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;<span style="color:rgb(36, 41, 47);"><p></p>(1). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(2). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(3). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Diagnosis.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(4). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sexuality.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(5). Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(6). Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(7). Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.</span><p></p>
-          <span style="color:rgb(36, 41, 47);">(8). Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.</span><p></p>
+        <td>Two bits for each Data Activity:
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process the specific category of Sensitive Data
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent
+        <p></p>(1) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin<p></p>
+          (2) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.<p></p>
+          (3) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Diagnosis.<p></p>
+          (4) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Sexuality.<p></p>
+          (5) Consent to Process the Consumer’s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.<p></p>
+          (6) Consent to Process the Consumer’s Sensitive Data Consisting of Genetic Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (7) Consent to Process the Consumer’s Sensitive Data Consisting of Biometric Data that May Be Processed for the Purpose of Uniquely Identifying an Individual.<p></p>
+          (8) Consent to Process the Consumer’s Sensitive Data Consisting of Precise Geolocation Data.<p></p>
         </td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">KnownChildSensitiveDataConsents</span>
+        <td><code>KnownChildSensitiveDataConsents</code>
         </td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Consent to Process Sensitive Data from a Known Child.</span><p></p><code>0</code> = Not Applicable, the Controller does not
-          <span style="color:rgb(36, 41, 47);">Process Sensitive Data of a known Child</span><p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;</td>
+        <td>Consent to Process Sensitive Data from a Known Child.
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Sensitive Data of a known Child
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">AdditionalDataProcessingConsent</span>
+        <td><code>AdditionalDataProcessingConsent</code>
         </td>
         <td>Int(2)</td>
-        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed<p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)<p></p><code>1</code> = No Consent<p></p><code>2</code> = Consent&nbsp;</td>
+        <td>Consent to Processing of the Consumer’s Personal Data that Is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s) for which the Consumer’s Personal Data Was Processed
+        <p></p><code>0</code> = Not Applicable, the Controller does not Process Personal Data that is Not Reasonably Necessary for nor Compatible with the Disclosed Purpose(s)
+        <p></p><code>1</code> = No Consent
+        <p></p><code>2</code> = Consent</td>
       </tr>
      <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaCoveredTransaction</span>
-        </td>
+        <td><code>MspaCoveredTransaction</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.&nbsp;</span><p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
+<p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multi-State Privacy Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a “Covered Transaction” as defined in the MSPA.
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaOptOutOptionMode</span>
-        </td>
+        <td><code>MspaOptOutOptionMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Opt-Out Option Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
       <tr>
-        <td>
-          <span style="color:rgb(36, 41, 47);">MspaServiceProviderMode</span>
-        </td>
+        <td><code>MspaServiceProviderMode</code></td>
         <td>Int(2)</td>
-        <td>
-          <span style="color:rgb(36, 41, 47);">Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.</span><p></p><code>0</code> = Not Applicable<p></p><code>1</code> = Yes<p></p><code>2</code> = No</td>
+        <td><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled “Service Provider Mode” for the “Covered Transaction,” as such terms are defined in the MSPA.
+        <p></p><code>0</code> = Not Applicable
+        <p></p><code>1</code> = Yes
+        <p></p><code>2</code> = No</td>
       </tr>
     </tbody>
   </table>
 </div>
-<h4>GPC Sub-section</h4>
-<p>
-  <a target="_blank" href="https://globalprivacycontrol.github.io/gpc-spec/">
-    <span style="color:rgb(17, 85, 204);">GPC</span>
-  </a>
-  <span style="color:rgb(36, 41, 47);">
-    is signaled in user agent headers
-  </span>
-  <span style="color:rgb(36, 41, 47);"><code>(Sec-GPC)</code></span>
-  <span style="color:rgb(36, 41, 47);">
-    and a simple javascript API
-  </span>
-  <span style="color:rgb(36, 41, 47);"><code>(globalPrivacyControl)</code></span>
-  <span style="color:rgb(36, 41, 47);">. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this sub-section.</span>
-</p>
+<h4>GPC Subsection</h4>
+<p><a href="https://w3c.github.io/gpc/" target="_blank" rel="noopener">GPC</a> is signaled in user agent headers<code>(Sec-GPC)</code> and a simple javascript API <code>(globalPrivacyControl)</code>. Entities creating GPP strings should check for whether GPC is set and pass along the value they find (from the headers or javascript API) in this subsection.</p>
 <div>
   <table>
     <tbody>
@@ -217,12 +204,12 @@
         </td>
       </tr>
       <tr>
-        <td>SubsectionType</td>
+        <td><code>SubsectionType</code></td>
         <td>Int(2)</td>
-        <td><p></p><code>0</code> = Core<p></p><code>1</code> = GPC</td>
+        <td><code>1</code> = GPC</td>
       </tr>
       <tr>
-        <td>Gpc</td>
+        <td><code>Gpc</code></td>
         <td>Boolean</td>
         <td><p></p><code>0</code> = false<p></p><code>1</code> = true</td>
       </tr>

--- a/Sections/US-States/TX/README.md
+++ b/Sections/US-States/TX/README.md
@@ -1,4 +1,4 @@
-# IAB Privacy’s Texas Privacy Technical Specification
+# Texas Privacy Technical Specification
 
 
  

--- a/Sections/US-States/UT/GPP Extension: Utah Privacy Technical Specification.md
+++ b/Sections/US-States/UT/GPP Extension: Utah Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-utah-privacy-technical-specification">GPP Extension: Utah Privacy Technical Specification</h1>
+<h1 id="gpp-extension-utah-privacy-technical-specification">Utah Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Utah section of the GPP specification by those who (i) are Signatories to IAB Privacy, Inc.’s <a href=https://www.iabprivacy.com/>Multi-State Privacy Agreement (MSPA)</a>; and (ii) those who are not signatories of the MSPA.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Utah section of the GPP specification.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>
@@ -10,6 +10,11 @@
 <td><strong>Date</strong></td>
 <td><strong>Version</strong></td>
 <td><strong>Comments</strong></td>
+</tr>
+<tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
 </tr>
 <tr>
 <td>December 2022</td>
@@ -48,8 +53,8 @@
 </table>
 <h3 id="section-encoding">Section encoding</h3>
 <p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
-<h4 id="core-segment">Core Segment</h4>
-<p>The core segment must always be present. Where terms are capitalized in the ‘description’ field they are defined terms in Utah Code 13-61-101. It consists of the following fields:</p>
+<h4 id="core-segment">Core Subsection</h4>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined terms in Utah Code 13-61-101. It consists of the following fields:</p>
 <table>
 <thead>
 <tr>
@@ -60,64 +65,77 @@
 </thead>
 <tbody>
 <tr>
-<td style="text-align:left">Version</td>
+<td style="text-align:left"><code>Version</code></td>
 <td style="text-align:left">Int(6)</td>
 <td style="text-align:left">The version of this section specification used to encode the string.</td>
 </tr>
 <tr>
-<td style="text-align:left">SharingNotice</td>
+<td style="text-align:left"><code>SharingNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Sharing of Personal Data with Third Parties<p><code>0</code> Not Applicable. The Controller does not share Personal Data with Third Parties.<p><code>1</code> Yes, notice was provided<p><code>2</code> No, notice was not provided</td>
 </tr>
 <tr>
-<td style="text-align:left">SaleOptOutNotice</td>
+<td style="text-align:left"><code>SaleOptOutNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Opportunity to Opt Out of the Sale of the Consumer&#39;s Personal Data<p><code>0</code> Not Applicable. The Controller does not Sell Personal Data.<p><code>1</code> Yes, notice was provided<p><code>2</code> No, notice was not provided</td>
 </tr>
 <tr>
-<td style="text-align:left">TargetedAdvertisingOptOutNotice</td>
+<td style="text-align:left"><code>TargetedAdvertisingOptOutNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Opportunity to Opt Out of Processing of the Consumer&#39;s Personal Data for Targeted Advertising<p><code>0</code> Not Applicable.The Controller does not Process Personal Data for Targeted Advertising.<p><code>1</code> Yes, notice was provided<p><code>2</code> No, notice was not provided</td>
 </tr>
 <tr>
-<td style="text-align:left">SensitiveDataProcessingOptOutNotice</td>
+<td style="text-align:left"><code>SensitiveDataProcessingOptOutNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Opportunity to Opt Out of the Processing of the Consumer&#39;s Sensitive Data<p><code>0</code> Not Applicable. The Controller does not Process Sensitive Data.<p><code>1</code> Yes, notice was provided<p><code>2</code> No, notice was not provided</td>
 </tr>
 <tr>
-<td style="text-align:left">SaleOptOut</td>
+<td style="text-align:left"><code>SaleOptOut</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Opt-Out of the Sale of the Consumer&#39;s Personal Data<p><code>0</code> Not Applicable. SaleOptOutNotice value was not applicable or no notice was provided<p><code>1</code> Opted Out<p><code>2</code> Did Not Opt Out</td>
 </tr>
 <tr>
-<td style="text-align:left">TargetedAdvertisingOptOut</td>
+<td style="text-align:left"><code>TargetedAdvertisingOptOut</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Opt-Out of Processing the Consumer&#39;s Personal Data for Targeted Advertising<p><code>0</code> Not Applicable. TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided<p><code>1</code> Opted Out<p><code>2</code> Did Not Opt Out</td>
 </tr>
 <tr>
-<td style="text-align:left">SensitiveDataProcessing</td>
+<td style="text-align:left"><code>SensitiveDataProcessing</code></td>
 <td style="text-align:left">N-Bitfield(2,8)</td>
-<td style="text-align:left">Two bits for each Data Activity:<p><code>0</code> Not Applicable. The Controller does not Process the specific category of Sensitive Data.<p><code>1</code> Opted Out<p><code>2</code> Did Not Opt Out<p>(1) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.<p>(2) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.<p>(3) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Sexual Orientation.<p>(4) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.<p>(5) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Medical History, Mental or Physical Health Condition, or Medical Treatment or Diagnosis by a Health Care Professional.<p>(6) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Genetic Data for the Purpose of Identifying a Specific Individual.<p>(7) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Biometric Data for the Purpose of Identifying a Specific Individual.<p>(8) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Specific Geolocation Data.</td>
+<td style="text-align:left">Two bits for each Data Activity:
+<p><code>0</code> Not Applicable. The Controller does not Process the specific category of Sensitive Data.<p><code>1</code> Opted Out
+<p><code>2</code> Did Not Opt Out
+<p>(1) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.
+<p>(2) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.
+<p>(3) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Sexual Orientation.
+<p>(4) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.
+<p>(5) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Medical History, Mental or Physical Health Condition, or Medical Treatment or Diagnosis by a Health Care Professional.
+<p>(6) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Genetic Data for the Purpose of Identifying a Specific Individual.
+<p>(7) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Biometric Data for the Purpose of Identifying a Specific Individual.
+<p>(8) Opt-Out of the Processing of the Consumer&#39;s Sensitive Data Consisting of Specific Geolocation Data.</td>
 </tr>
 <tr>
-<td style="text-align:left">KnownChildSensitiveDataConsents</td>
+<td style="text-align:left"><code>KnownChildSensitiveDataConsents</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Consent to Process Sensitive Data from a Known Child<p><code>0</code> Not Applicable. The Controller does not Process Sensitive Data of a known Child.<p><code>1</code> No Consent<p><code>2</code> Consent</td>
 </tr>
 <tr>
-<td style="text-align:left">MspaCoveredTransaction</td>
+<td style="text-align:left"><code>MspaCoveredTransaction</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Publisher or Advertiser, as applicable, is a signatory to the IAB Multistate Service Provider Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a &quot;Covered Transaction&quot; as defined in the MSPA.<p><code>1</code> Yes<p><code>2</code> No</td>
+<td style="text-align:left"><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
+<p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multistate Service Provider Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a &quot;Covered Transaction&quot; as defined in the MSPA.<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 <tr>
-<td style="text-align:left">MspaOptOutOptionMode</td>
+<td style="text-align:left"><code>MspaOptOutOptionMode</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Publisher or Advertiser, as applicable, has enabled &quot;Opt-Out Option Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
+<td style="text-align:left"><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled &quot;Opt-Out Option Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 <tr>
-<td style="text-align:left">MspaServiceProviderMode</td>
+<td style="text-align:left"><code>MspaServiceProviderMode</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Publisher or Advertiser, as applicable, has enabled &quot;Service Provider Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
+<td style="text-align:left"><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled &quot;Service Provider Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 </tbody>
 </table>

--- a/Sections/US-States/VA/GPP Extension: Virginia Privacy Technical Specification.md
+++ b/Sections/US-States/VA/GPP Extension: Virginia Privacy Technical Specification.md
@@ -1,6 +1,6 @@
-<h1 id="gpp-extension-virginia-privacy-technical-specification">GPP Extension: Virginia Privacy Technical Specification</h1>
+<h1 id="gpp-extension-virginia-privacy-technical-specification">Virginia Privacy Technical Specification</h1>
 <h2 id="about-this-document">About this document</h2>
-<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Virginia section of the GPP specification by those who (i) are Signatories to IAB Privacy, Inc.’s <a href=https://www.iabprivacy.com/>Multi-State Privacy Agreement (MSPA)</a>; and (ii) those who are not signatories of the MSPA.</p>
+<p>The global standard <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform">GPP</a> defines a way for local standards to &quot;plug-in&quot; to the existing mechanics defined by GPP and the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md">GPP client side API</a>. This document outlines the technical specification for using the Virginia section of the GPP specification.</p>
 
 <h3>Version History&nbsp;</h3>
 <div>
@@ -10,6 +10,11 @@
 <td><strong>Date</strong></td>
 <td><strong>Version</strong></td>
 <td><strong>Comments</strong></td>
+</tr>
+<tr>
+<td>August 2026 (<i>Public Comment</i>)</td>
+<td>1.0</td>
+<td>Updated guidance on usage of MSPA-specific fields in accordance with the Fifth Amended and Restated MSPA</td>
 </tr>
 <tr>
 <td>December 2022</td>
@@ -48,8 +53,8 @@
 </table>
 <h3 id="section-encoding">Section encoding</h3>
 <p>Note on the JS representation of the section: the field name should be in UpperCamelCase, with exactly the same spelling as the names in column "Field name". Follow <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/Consent%20String%20Specification.md#section-encoding" target="_blank" rel="noopener">this table</a> to map the GPP field types to JavaScript native data types. Please refer to the <a href="https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#pingreturn-" target="_blank" rel="noopener">PingReturn's parsedSections object</a> for an example.<p>
-<h4 id="core-segment">Core Segment</h4>
-<p>The core segment must always be present. Where terms are capitalized in the ‘description’ field they are defined terms in Virginia Code 59.1-575. It consists of the following fields:</p>
+<h4 id="core-segment">Core Subsection</h4>
+<p>The core subsection must always be present. Where terms are capitalized in the ‘description’ column they are defined terms in Virginia Code 59.1-575. It consists of the following fields:</p>
 <table>
 <thead>
 <tr>
@@ -60,59 +65,75 @@
 </thead>
 <tbody>
 <tr>
-<td style="text-align:left">Version</td>
+<td style="text-align:left"><code>Version</code></td>
 <td style="text-align:left">Int(6)</td>
 <td style="text-align:left">The version of this section specification used to encode the string.</td>
 </tr>
 <tr>
-<td style="text-align:left">SharingNotice</td>
+<td style="text-align:left"><code>SharingNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Sharing of Personal Data with Third Parties<p><code>0</code> Not Applicable. The Controller does not share Personal Data with Third Parties.<p><code>1</code> Yes, notice was provided<p><code>2</code> No, notice was not provided</td>
 </tr>
 <tr>
-<td style="text-align:left">SaleOptOutNotice</td>
+<td style="text-align:left"><code>SaleOptOutNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Opportunity to Opt Out of the Sale of the Consumer&#39;s Personal Data<p><code>0</code> Not Applicable. The Controller does not Sell Personal Data.<p><code>1</code> Yes, notice was provided<p><code>2</code> No, notice was not provided</td>
 </tr>
 <tr>
-<td style="text-align:left">TargetedAdvertisingOptOutNotice</td>
+<td style="text-align:left"><code>TargetedAdvertisingOptOutNotice</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Notice of the Opportunity to Opt Out of Processing of the Consumer&#39;s Personal Data for Targeted Advertising<p><code>0</code> Not Applicable.The Controller does not Process Personal Data for Targeted Advertising.<p><code>1</code> Yes, notice was provided<p><code>2</code> No, notice was not provided</td>
 </tr>
 <tr>
-<td style="text-align:left">SaleOptOut</td>
+<td style="text-align:left"><code>SaleOptOut</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Opt-Out of the Sale of the Consumer&#39;s Personal Data<p><code>0</code> Not Applicable. SaleOptOutNotice value was not applicable or no notice was provided<p><code>1</code> Opted Out<p><code>2</code> Did Not Opt Out</td>
 </tr>
 <tr>
-<td style="text-align:left">TargetedAdvertisingOptOut</td>
+<td style="text-align:left"><code>TargetedAdvertisingOptOut</code></td>
 <td style="text-align:left">Int(2)</td>
 <td style="text-align:left">Opt-Out of Processing the Consumer&#39;s Personal Data for Targeted Advertising<p><code>0</code> Not Applicable. TargetedAdvertisingOptOutNotice value was not applicable or no notice was provided<p><code>1</code> Opted Out<p><code>2</code> Did Not Opt Out</td>
 </tr>
 <tr>
-<td style="text-align:left">SensitiveDataProcessing</td>
+<td style="text-align:left"><code>SensitiveDataProcessing</code></td>
 <td style="text-align:left">N-Bitfield(2,8)</td>
-<td style="text-align:left">Two bits for each Data Activity:<p><code>0</code> Not Applicable. The Controller does not Process the specific category of Sensitive Data.<p><code>1</code> No Consent<p><code>2</code> Consent<p>(1) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.<p>(2) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.<p>(3) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Diagnosis.<p>(4) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Sexual Orientation.<p>(5) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.<p>(6) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Genetic Data for the Purpose of Uniquely Identifying a Natural Person.<p>(7) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Biometric Data for the Purpose of Uniquely Identifying a Natural Person.<p>(8) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Precise Geolocation Data.</td>
+<td style="text-align:left">Two bits for each Data Activity:
+<p><code>0</code> Not Applicable. The Controller does not Process the specific category of Sensitive Data.
+<p><code>1</code> No Consent
+<p><code>2</code> Consent
+<p>(1) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Racial or Ethnic Origin.
+<p>(2) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Religious Beliefs.
+<p>(3) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing a Mental or Physical Health Diagnosis.
+<p>(4) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Sexual Orientation.
+<p>(5) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Personal Data Revealing Citizenship or Immigration Status.
+<p>(6) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Genetic Data for the Purpose of Uniquely Identifying a Natural Person.
+<p>(7) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Biometric Data for the Purpose of Uniquely Identifying a Natural Person.
+<p>(8) Consent to Process the Consumer&#39;s Sensitive Data Consisting of Precise Geolocation Data.</td>
 </tr>
 <tr>
-<td style="text-align:left">KnownChildSensitiveDataConsents</td>
+<td style="text-align:left"><code>KnownChildSensitiveDataConsents</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Consent to Process Sensitive Data from a Known Child<p><code>0</code> Not Applicable. The Controller does not Process Sensitive Data of a known Child.<p><code>1</code> No Consent<p><code>2</code> Consent</td>
+<td style="text-align:left">Consent to Process Sensitive Data from a Known Child
+<p><code>0</code> Not Applicable. The Controller does not Process Sensitive Data of a known Child.<p><code>1</code> No Consent
+<p><code>2</code> Consent</td>
 </tr>
 <tr>
-<td style="text-align:left">MspaCoveredTransaction</td>
+<td style="text-align:left"><code>MspaCoveredTransaction</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Publisher or Advertiser, as applicable, is a signatory to the IAB Multistate Service Provider Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a &quot;Covered Transaction&quot; as defined in the MSPA.<p><code>1</code> Yes<p><code>2</code> No</td>
+<td style="text-align:left"><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>2</code>.</b>
+<p>Publisher or Advertiser, as applicable, is a signatory to the IAB Multistate Service Provider Agreement (MSPA), as may be amended from time to time, and declares that the transaction is a &quot;Covered Transaction&quot; as defined in the MSPA.<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 <tr>
-<td style="text-align:left">MspaOptOutOptionMode</td>
+<td style="text-align:left"><code>MspaOptOutOptionMode</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Publisher or Advertiser, as applicable, has enabled &quot;Opt-Out Option Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
+<td style="text-align:left"><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled &quot;Opt-Out Option Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 <tr>
-<td style="text-align:left">MspaServiceProviderMode</td>
+<td style="text-align:left"><code>MspaServiceProviderMode</code></td>
 <td style="text-align:left">Int(2)</td>
-<td style="text-align:left">Publisher or Advertiser, as applicable, has enabled &quot;Service Provider Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
+<td style="text-align:left"><b>Note: As of the Fifth Amended and Restated MSPA, this field should not be used and must always be set to <code>0</code>.</b>
+<p>Publisher or Advertiser, as applicable, has enabled &quot;Service Provider Mode&quot; for the &quot;Covered Transaction,&quot; as such terms are defined in the MSPA.<p><code>0</code> Not Applicable<p><code>1</code> Yes<p><code>2</code> No</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
This PR updates all US sections of the GPP to reflect updates made to the [Fifth Amended and Restated MSPA](https://www.iabprivacy.com/).

These updates are open for public comment until **September 11th, 2026**. Comments may be submitted by sending an email to support@iabtechlab.om or as comments on this PR. 

**Changes**:
- The MSPA US National Section (Section ID 7) updated to use the new string structure that was introduced with the Maryland, Indiana, Kentucky, and Rhode Island sections allowing for improved flexibility and future-proofing.
- The MSPA US National Section (Section ID 7) simplified to include just the following fields in the Core Subsection: `MspaVersion`, `MspaNotice`, `MspaOptOut`, `MspaId`
- Addition of the MSPA List Specification, a specification for the updated MSPA signatory list json file that participants may use to determine the MSPA ids of other signatories and Certified Partners
- All US state sections (Section IDs 8 - 27) updated guidance on usage of MSPA-related fields:
  - Where `MspaVersion` is included, this must always be `0`
  -  Where `MspaCoveredTransaction` is included, this must always be `2`, not covered
  -  Where `MspaMode ` is included, this must always be `0`, not applicable
  -  Where `MspaOptOutOptionMode ` is included, this must always be `0`, not applicable
  -  Where `MspaServiceProviderMode ` is included, this must always be `0`, not applicable
- Other miscellaneous cleanup:
  -  Added links to all section specific specifications in [Section Information ](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/Section%20Information.md)
  - Formatting updates in all specs
  - Fixed broken links to Global Privacy Control (GPC) documentation
  - Updated all usage of the term 'segment' to 'subsection' for consistency 